### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ yargs(hideBin(process.argv))
     () => {},
     () => {
       console.log(currentText);
+      process.exitCode = 1;
     },
   )
   .command(

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -26,9 +26,9 @@ async function runCli(args: string[]) {
 describe("cli", () => {
   test("hello prints the current text", async () => {
     const result = await runCli(["hello"]);
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(1);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
## Summary
Generated by o-agents.

## Source
https://github.com/exKAZUu/agent-benchmark/issues/1

Closes #1

## Original Description
Print "Hello, World!" instead of "Hello via Bun!".
Then, exit with the status code 1.