### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ yargs(hideBin(process.argv))
     () => {},
     () => {
       console.log(currentText);
+      process.exitCode = 1;
     },
   )
   .command(


### PR DESCRIPTION
## Summary
Updated greeting to 'Hello, World!' and set hello command to exit with status code 1. Tests not run (per instructions).

## Plan
Plan:
1) Locate the code path that prints the current greeting (search for "Hello via Bun!") and identify the entry point responsible for CLI output.
2) Update the output string to exactly "Hello, World!" and ensure the program exits with status code 1 after printing (e.g., set process exit code or call exit).
3) Run the project’s standard test or execution command to confirm the output and exit status, then report results.

## Source
https://github.com/exKAZUu/agent-benchmark/issues/1

Closes #1

## Original Description
Print "Hello, World!" instead of "Hello via Bun!".
Then, exit with the status code 1.