### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
## Summary
bun test: 6 pass, 0 fail

## Plan
Plan:
1) Locate the entry point that prints the greeting (search for "Hello via Bun!").
2) Update the string to "Hello, World!" and ensure any related tests or docs expecting the old message are adjusted if present.
3) Run the project’s quick check or test (if configured) to confirm the output matches.

## Source
https://github.com/exKAZUu/agent-benchmark/issues/1

Closes #1

## Original Description
Print "Hello, World!" instead of "Hello via Bun!".