### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate, currentText } from "../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {
@@ -16,5 +16,11 @@ describe("calculate", () => {
 
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
+  });
+});
+
+describe("currentText", () => {
+  test("prints Hello, World!", () => {
+    expect(currentText).toBe("Hello, World!");
   });
 });


### PR DESCRIPTION
## Summary
Added unit test to lock currentText to 'Hello, World!' and verified with bun test. Commit: 06abc89.

## Plan
Plan:
1) Locate the program entry point (likely main file) that prints "Hello via Bun!" and confirm the exact string and output path.
2) Update the output to print exactly "Hello, World!" and ensure no extra text or punctuation.
3) Re-run or inspect any existing lightweight checks (if present) to confirm output matches the requirement.

## Source
https://github.com/exKAZUu/agent-benchmark/issues/1

Closes #1

## Original Description
Print "Hello, World!" instead of "Hello via Bun!".