### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate } from "./cli";
+
+const helloText = "Hello, World!";
 
 yargs(hideBin(process.argv))
   .command(
@@ -8,7 +10,7 @@ yargs(hideBin(process.argv))
     "Print the current text",
     () => {},
     () => {
-      console.log(currentText);
+      console.log(helloText);
     },
   )
   .command(


### PR DESCRIPTION
## Summary
Updated src/cli.ts to print 'Hello, World!'. Committed as fix: print hello world with Closes #1 footer. Pushed branch o-agents/issue-1-20260105-235833.

## Plan
**Plan**
- Identify where the greeting string is emitted (likely entrypoint such as // file) and confirm the current text.
- Update the output string to exactly  and ensure no other variants remain.
- Run any existing quick sanity check (e.g., Usage: bun run [flags] <file or script>

Flags:
      --silent                        Don't print the script command
      --elide-lines=<val>             Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines.
  -F, --filter=<val>                  Run a script in all workspace packages matching the pattern
  -b, --bun                           Force a script or package to use Bun's runtime instead of Node.js (via symlinking node)
      --shell=<val>                   Control the shell used for package.json scripts. Supports either 'bun' or 'system'
      --workspaces                    Run a script in all workspace packages (from the "workspaces" field in package.json)
      --watch                         Automatically restart the process on file change
      --hot                           Enable auto reload in the Bun runtime, test runner, or bundler
      --no-clear-screen               Disable clearing the terminal screen on reload when --hot or --watch is enabled
      --smol                          Use less memory, but run garbage collection more often
  -r, --preload=<val>                 Import a module before other modules are loaded
      --require=<val>                 Alias of --preload, for Node.js compatibility
      --import=<val>                  Alias of --preload, for Node.js compatibility
      --inspect=<val>                 Activate Bun's debugger
      --inspect-wait=<val>            Activate Bun's debugger, wait for a connection before executing
      --inspect-brk=<val>             Activate Bun's debugger, set breakpoint on first line of code and wait
      --cpu-prof                      Start CPU profiler and write profile to disk on exit
      --cpu-prof-name=<val>           Specify the name of the CPU profile file
      --cpu-prof-dir=<val>            Specify the directory where the CPU profile will be saved
      --if-present                    Exit without an error if the entrypoint does not exist
      --no-install                    Disable auto install in the Bun runtime
      --install=<val>                 Configure auto-install behavior. One of "auto" (default, auto-installs when no node_modules), "fallback" (missing packages only), "force" (always).
  -i                                  Auto-install dependencies during execution. Equivalent to --install=fallback.
  -e, --eval=<val>                    Evaluate argument as a script
  -p, --print=<val>                   Evaluate argument as a script and print the result
      --prefer-offline                Skip staleness checks for packages in the Bun runtime and resolve from disk
      --prefer-latest                 Use the latest matching versions of packages in the Bun runtime, always checking npm
      --port=<val>                    Set the default port for Bun.serve
      --conditions=<val>              Pass custom conditions to resolve
      --fetch-preconnect=<val>        Preconnect to a URL while code is loading
      --max-http-header-size=<val>    Set the maximum size of HTTP headers in bytes. Default is 16KiB
      --dns-result-order=<val>        Set the default order of DNS lookup results. Valid orders: verbatim (default), ipv4first, ipv6first
      --expose-gc                     Expose gc() on the global object. Has no effect on Bun.gc().
      --no-deprecation                Suppress all reporting of the custom deprecation.
      --throw-deprecation             Determine whether or not deprecation warnings result in errors.
      --title=<val>                   Set the process title
      --zero-fill-buffers             Boolean to force Buffer.allocUnsafe(size) to be zero-filled.
      --use-system-ca                 Use the system's trusted certificate authorities
      --use-openssl-ca                Use OpenSSL's default CA store
      --use-bundled-ca                Use bundled CA store
      --redis-preconnect              Preconnect to $REDIS_URL at startup
      --sql-preconnect                Preconnect to PostgreSQL at startup
      --no-addons                     Throw an error if process.dlopen is called, and disable export condition "node-addons"
      --unhandled-rejections=<val>    One of "strict", "throw", "warn", "none", or "warn-with-error-code"
      --console-depth=<val>           Set the default depth for console.log object inspection (default: 2)
      --user-agent=<val>              Set the default User-Agent header for HTTP requests
      --main-fields=<val>             Main fields to lookup in package.json. Defaults to --target dependent
      --preserve-symlinks             Preserve symlinks when resolving files
      --preserve-symlinks-main        Preserve symlinks when resolving the main entry point
      --extension-order=<val>         Defaults to: .tsx,.ts,.jsx,.js,.json
      --tsconfig-override=<val>       Specify custom tsconfig.json. Default <d>$cwd<r>/tsconfig.json
  -d, --define=<val>                  Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:"development". Values are parsed as JSON.
      --drop=<val>                    Remove function calls, e.g. --drop=console removes all console.* calls.
      --feature=<val>                 Enable a feature flag for dead-code elimination, e.g. --feature=SUPER_SECRET
  -l, --loader=<val>                  Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi
      --no-macros                     Disable macros from being executed in the bundler, transpiler and runtime
      --jsx-factory=<val>             Changes the function called when compiling JSX elements using the classic JSX runtime
      --jsx-fragment=<val>            Changes the function called when compiling JSX fragments
      --jsx-import-source=<val>       Declares the module specifier to be used for importing the jsx and jsxs factory functions. Default: "react"
      --jsx-runtime=<val>             "automatic" (default) or "classic"
      --jsx-side-effects              Treat JSX elements as having side effects (disable pure annotations)
      --ignore-dce-annotations        Ignore tree-shaking annotations such as @__PURE__
      --env-file=<val>                Load environment variables from the specified file(s)
      --no-env-file                   Disable automatic loading of .env files
      --cwd=<val>                     Absolute path to resolve files & entry points from. This just changes the process' cwd.
  -c, --config=<val>                  Specify path to Bun config file. Default <d>$cwd<r>/bunfig.toml
  -h, --help                          Display this menu and exit

Examples:
  Run a JavaScript or TypeScript file
  bun run ./index.js
  bun run ./index.tsx

  Run a package.json script
  bun run dev
  bun run lint

Full documentation is available at https://bun.com/docs/cli/run

No "scripts" found in package.json. or tests) if present to verify the output matches the requirement.

## Source
https://github.com/exKAZUu/agent-benchmark/issues/1

Closes #1

## Original Description
Print "Hello, World!" instead of "Hello via Bun!".