### PR TITLE
feat: support modulo operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,10 @@ To run:
 bun run src/index.ts
 ```
 
+Example:
+
+```bash
+bun run src/index.ts calc 10 % 3
+```
+
 This project was created using `bun init` in bun v1.3.5. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,5 +14,11 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left / right;
     case "%":
       return left % right;
+    default:
+      return assertNever(operator);
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unsupported operator: ${value}`);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
# Change Summary
- Added `%` operator support in the calculator core and CLI argument choices/types.
- Added unit and end-to-end coverage for modulo behavior.
- Documented a modulo usage example in the README.

# Tests
- Not run (per instructions).

## Plan
# Implementation Plan: Support Modulo Operator

## Goal
Add support for the modulo (`%`) operator to the CLI calculator and its underlying calculation logic, ensuring unit and end-to-end tests cover the new behavior.

## Scope and Assumptions
- The calculator currently supports `+`, `-`, `*`, `/` and exposes a `calc <left> <operator> <right>` CLI command.
- Modulo behavior follows JavaScript’s remainder operator semantics (`a % b`).
- No new external libraries or APIs are required.

## Relevant Files (Reviewed)
- `src/cli.ts`: Defines `Operator` type and `calculate` implementation.
- `src/index.ts`: CLI definition, operator choices, and argument parsing.
- `tests/unit.test.ts`: Unit tests for `calculate`.
- `tests/e2e.test.ts`: CLI integration tests.
- `README.md`: Basic usage documentation.

## Plan

### 1) Extend core operator type and calculation logic
- Update `Operator` in `src/cli.ts` to include `%`.
- Extend the `calculate` switch statement with a `%` case that returns `left % right`.
- Ensure TypeScript remains exhaustive; if needed, add a default unreachable branch or rely on union narrowing.

### 2) Update CLI operator choices and typing
- In `src/index.ts`, add `%` to the `choices` array for the `operator` positional argument.
- Update the local `operator` type annotation to include `%` so the CLI invocation compiles and is type-safe.

### 3) Add unit test coverage for modulo
- In `tests/unit.test.ts`, add a new test case (e.g., `calculate(10, "%", 3)` yields `1`).
- Consider adding a second case that validates negative or fractional behavior only if the project conventions expect it (otherwise keep a single canonical test).

### 4) Add CLI end-to-end coverage for modulo
- In `tests/e2e.test.ts`, add a test that runs `calc 10 % 3` and asserts output `1`, empty stderr, and exit code `0`.

### 5) Documentation update (optional but recommended)
- In `README.md`, add an example that demonstrates modulo usage (e.g., `bun run src/index.ts calc 10 % 3`).

## Validation Checklist
- `bun test` passes all unit and e2e tests.
- `bun run src/index.ts calc 10 % 3` prints `1`.

## Notes
- No external libraries or API changes are needed for this request.

## Source
https://github.com/exKAZUu/agent-benchmark/issues/4

Closes #4

## Original Description
In addition to four arithmetic operations, support modulo operator.