### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,5 +14,9 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left / right;
     case "%":
       return left % right;
+    default: {
+      const unreachable: never = operator;
+      throw new Error(`Unsupported operator: ${unreachable}`);
+    }
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
**Change Summary**
- Added `%` support to core operator type and calculation logic.
- Allowed `%` in the CLI operator choices and handler typing.
- Added unit and CLI e2e coverage for modulo behavior.

**Tests**
- Not run (per instructions).

## Plan
# Implementation Plan: Add Modulo Operator Support

## Understanding of Current Implementation
- CLI is defined in `src/index.ts` using `yargs` with a `calc` command that accepts `left`, `operator`, and `right`, and restricts `operator` to `+`, `-`, `*`, `/`.
- Core arithmetic logic is in `src/cli.ts` via `calculate(left, operator, right)` with an `Operator` union type and a switch for the four operations.
- Tests:
  - Unit tests in `tests/unit.test.ts` cover the four operations.
  - E2E test in `tests/e2e.test.ts` validates the CLI `calc` behavior for `+`.

## Assumptions
- Modulo follows JavaScript’s `%` operator semantics (remainder, not mathematical modulo), consistent with the other operations using native JS arithmetic.
- `calc` should accept `%` as a valid operator from the CLI and return the numeric remainder.

## Plan
1. Update core operator typing and logic
   - In `src/cli.ts`, extend `Operator` to include `%`.
   - Add a new `case "%": return left % right;` to `calculate`.
   - Ensure the function remains exhaustive (no default needed if TypeScript infers all cases).

2. Extend CLI operator validation
   - In `src/index.ts`, include `%` in the `choices` array for the `operator` positional argument.
   - Update the inferred `operator` type in the handler to include `%` to match `Operator`.

3. Add unit coverage for modulo
   - In `tests/unit.test.ts`, add a test like `calculate(10, "%", 3) === 1`.
   - Optionally add a negative or zero-right operand case if desired for clarity (e.g., `calculate(10, "%", 0)` results in `NaN`), but keep consistent with current simple positive-number tests.

4. Add CLI e2e coverage
   - In `tests/e2e.test.ts`, add a `calc` test invoking `calc 10 % 3` and assert output is `1`.
   - Keep the output check aligned with current behavior (stdout only, no extra text).

5. Documentation (optional but recommended)
   - Update `README.md` with a brief mention that `calc` supports `%` if the project documents operators in the future.

## Validation Steps
- Run unit tests: `bun test tests/unit.test.ts`
- Run e2e tests: `bun test tests/e2e.test.ts`
- (Optional) Run all tests: `bun test`

## No External Dependencies
- No new libraries or external APIs are required.

## Source
https://github.com/exKAZUu/agent-benchmark/issues/4

Closes #4

## Original Description
In addition to four arithmetic operations, support modulo operator.