### PR TITLE
feat: support modulo operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,10 @@ To run:
 bun run src/index.ts
 ```
 
+Calculator usage (operators: `+`, `-`, `*`, `/`, `%`):
+
+```bash
+bun run src/index.ts calc 10 % 3
+```
+
 This project was created using `bun init` in bun v1.3.5. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,5 +14,9 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left / right;
     case "%":
       return left % right;
+    default: {
+      const unreachable: never = operator;
+      throw new Error(`Unsupported operator: ${unreachable}`);
+    }
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,12 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
+
+  test("modulo keeps remainder sign", () => {
+    expect(calculate(-10, "%", 3)).toBe(-1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
- Added modulo operator support in core `calculate` and CLI argument validation to accept `%`.
- Expanded unit and CLI e2e coverage for modulo, including negative remainder behavior.
- Documented modulo usage in the README.

## Plan
# Implementation Plan: Support Modulo Operator

## Goal
Add modulo (`%`) to the supported arithmetic operators in both the CLI and core calculation logic, with tests and documentation updated accordingly.

## Assumptions
- Use JavaScript/TypeScript `%` operator semantics (remainder, not mathematical modulo), including behavior with negative numbers and non-integers.
- No external libraries are required.

## Relevant Files
- `src/cli.ts`: operator type and `calculate` implementation.
- `src/index.ts`: CLI argument validation (operator choices) and runtime typing.
- `tests/unit.test.ts`: unit coverage for `calculate`.
- `tests/e2e.test.ts`: CLI coverage.
- `README.md`: optional usage documentation update.

## Plan
1. **Update core operator type and calculation logic**
   - In `src/cli.ts`, extend `Operator` union to include `%`.
   - Add a `case "%"` branch to `calculate` returning `left % right`.
   - Consider whether any explicit default case or unreachable guard is needed for exhaustiveness (TypeScript may allow fallthrough if not all cases covered).

2. **Expand CLI operator validation and typing**
   - In `src/index.ts`, include `%` in the `choices` array for the `operator` positional argument.
   - Update the `operator` type assertion to include `%`.
   - Ensure CLI still prints only the numeric result.

3. **Add unit tests for modulo**
   - In `tests/unit.test.ts`, add a test that asserts `calculate(10, "%", 3)` returns `1`.
   - Optionally add a test for negative or non-integer inputs if desired to lock in `%` semantics (e.g., `calculate(-10, "%", 3)` returns `-1`).

4. **Add CLI e2e test for modulo**
   - In `tests/e2e.test.ts`, add a test that runs `calc 10 % 3` and asserts stdout is `"1"`, with no stderr and exit code `0`.
   - Ensure the operator is passed as a literal `%` argument; if shell escaping is needed in test harness, use the raw array argument already in place.

5. **Update documentation (optional but recommended)**
   - In `README.md`, add an example or note that modulo is supported alongside `+ - * /`.

6. **Verification**
   - Run `bun test` to confirm unit and e2e tests pass.
   - Run `bun run src/index.ts calc 10 % 3` to manually verify CLI behavior if needed.