### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const OPERATORS = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof OPERATORS)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -13,6 +15,9 @@ export function calculate(left: number, operator: Operator, right: number): numb
     case "/":
       return left / right;
     case "%":
+      if (right === 0) {
+        throw new Error("Division by zero");
+      }
       return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, OPERATORS, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/", "%"] as const,
+          choices: OPERATORS,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Implementation Summary - Support Modulo Operator

Added support for the modulo operator (`%`) to the calculator CLI.

## Changes

### Core Logic (`src/cli.ts`)
- Updated `Operator` type to include `%`.
- Extended `calculate` function to handle `%` operator.

### CLI Interface (`src/index.ts`)
- Updated `yargs` command definition to accept `%` as a valid operator.
- Updated operator type casting.

### Tests
- Added unit test for modulo operation in `tests/unit.test.ts`.
- Added E2E test for `calc 10 % 3` in `tests/e2e.test.ts`.

## Plan
# Implementation Plan - Support Modulo Operator

This plan outlines the steps to add support for the modulo operator (`%`) to the calculator CLI.

## User Story

As a user, I want to perform modulo operations using the CLI so that I can calculate the remainder of division.

## Proposed Changes

### 1. Update Core Logic (`src/cli.ts`)

- **Goal**: Extend the `calculate` function and `Operator` type to support `%`.
- **Files**: `src/cli.ts`
- **Changes**:
    - Update `Operator` type definition:
      ```typescript
      export type Operator = "+" | "-" | "*" | "/" | "%";
      ```
    - Update `calculate` function switch statement:
      ```typescript
      case "%":
        return left % right;
      ```

### 2. Update CLI Interface (`src/index.ts`)

- **Goal**: Allow the `%` operator to be passed as an argument to the `calc` command.
- **Files**: `src/index.ts`
- **Changes**:
    - Update the `choices` array in the `yargs` command definition for `calc`:
      ```typescript
      choices: ["+", "-", "*", "/", "%"] as const,
      ```
    - Update the `operator` variable type casting:
      ```typescript
      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
      ```

### 3. Verification (Tests)

- **Goal**: Ensure the new operator works correctly and doesn't break existing functionality.
- **Files**:
    - `tests/unit.test.ts`
    - `tests/e2e.test.ts`
- **Changes**:
    - Add a unit test in `tests/unit.test.ts`:
      ```typescript
      test("modulos", () => {
        expect(calculate(10, "%", 3)).toBe(1);
      });
      ```
    - Add an E2E test in `tests/e2e.test.ts`:
      ```typescript
      test("calc modulo", async () => {
        const result = await runCli(["calc", "10", "%", "3"]);
        expect(result.exitCode).toBe(0);
        expect(result.stderr).toBe("");
        expect(result.stdout).toBe("1");
      });
      ```

## Verification Steps

1.  Run `bun test` to execute the test suite.
2.  Manually test the CLI:
    ```bash
    bun run src/index.ts calc 10 % 3
    ```