### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,5 +14,9 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left / right;
     case "%":
       return left % right;
+    default: {
+      const unreachable: never = operator;
+      throw new Error(`Unsupported operator: ${unreachable}`);
+    }
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Updated calculator and CLI to accept modulo (%) operations, wiring choices and type support.
Added modulo unit and CLI e2e tests to cover % behavior.

Tests not run (per instructions).

## Plan
**Plan**
- **Scope review**: Confirm current calculator logic and CLI parsing in `src/cli.ts`, CLI command wiring in `src/index.ts`, and test coverage in `tests/unit.test.ts` and `tests/e2e.test.ts`. No external libraries are used or needed for modulo; rely on JavaScript `%` remainder semantics.
- **Extend operator typing and parsing**: Add `%` to the `Operator` union in `src/cli.ts`, update the `calculate` switch to handle `%`, and ensure the function returns `left % right` for modulo. Keep the default behavior consistent with current arithmetic operations (no extra error handling unless already present).
- **Update CLI command validation**: Include `%` in the `choices` list for the `operator` positional argument in `src/index.ts`, and update the inferred operator type in the handler to include `%` so CLI accepts and routes modulo correctly.
- **Add unit tests**: In `tests/unit.test.ts`, add a new test for modulo, e.g., `calculate(10, "%", 3)` returns `1`. Consider adding a second case (like `calculate(10, "%", 5) === 0`) if you want clearer coverage of exact division; keep tests aligned with existing style.
- **Add e2e CLI test**: In `tests/e2e.test.ts`, add a CLI test that runs `calc 10 % 3` and asserts stdout is `1`, stderr empty, exit code 0. This ensures CLI parsing and execution paths support the new operator.
- **Documentation check (optional)**: If the CLI usage is documented elsewhere (e.g., `README.md`), add `%` to any operator lists or examples. If no operator list exists, skip changes.
- **Validation**: Run `bun test` to ensure unit and e2e tests pass and new operator works end-to-end.