### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,5 +14,9 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left / right;
     case "%":
       return left % right;
+    default: {
+      const unsupported: never = operator;
+      throw new Error(`Unsupported operator: ${unsupported}`);
+    }
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo support across the calculator core, CLI, and tests.

- Updated `src/cli.ts` to include `%` in `Operator` and handle modulo in `calculate`.
- Extended CLI operator choices and typing in `src/index.ts`.
- Added unit and e2e coverage for modulo in `tests/unit.test.ts` and `tests/e2e.test.ts`.

Tests not run (per instructions).

## Plan
# Implementation Plan: Support Modulo Operator

## Context Summary
- CLI defined in `src/index.ts` uses yargs with an operator choice list limited to `+ - * /`.
- Core arithmetic logic is in `src/cli.ts` with `Operator` union and `calculate` switch.
- Tests cover arithmetic in `tests/unit.test.ts` and CLI in `tests/e2e.test.ts`.
- No external libraries are needed for modulo; JavaScript `%` is sufficient.

## Assumptions
- Modulo should follow JavaScript numeric remainder semantics (`a % b`).
- Modulo by zero behavior can rely on JS (`NaN`), unless a more explicit error is desired.

## Plan
1. **Update operator typing and calculation**
   - Edit `src/cli.ts`:
     - Extend `Operator` to include `%`.
     - Add a `%` case to `calculate` returning `left % right`.
     - Ensure switch remains exhaustive; if a default is required by TypeScript, keep it consistent with existing style.

2. **Expose modulo in the CLI**
   - Edit `src/index.ts`:
     - Add `%` to yargs `choices` for `operator`.
     - Update the operator type in the handler to include `%` (or reuse the `Operator` type from `src/cli.ts` if preferred).

3. **Expand unit tests**
   - Edit `tests/unit.test.ts`:
     - Add a test case like `calculate(10, "%", 4) === 2`.
     - Optionally add a negative or float test if the project expects real-number support (e.g., `5.5 % 2`).

4. **Expand CLI E2E tests**
   - Edit `tests/e2e.test.ts`:
     - Add a CLI test `calc 10 % 4` and assert output `2`.
     - Ensure `%` is passed as a distinct argument (already structured as args array).

5. **(Optional) Documentation**
   - If user-facing usage is documented, update `README.md` to mention `%` as supported. Current README does not list operators, so this may be skipped unless desired.

6. **Verification**
   - Run tests with `bun test`.
   - Optionally run `bun run src/index.ts calc 10 % 4` to confirm output.

## Files to Change
- `src/cli.ts`
- `src/index.ts`
- `tests/unit.test.ts`
- `tests/e2e.test.ts`
- `README.md` (optional)