### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,6 @@ export function calculate(left: number, operator: Operator, right: number): numb
     case "/":
       return left / right;
     case "%":
-      return left % right;
+      return ((left % right) + right) % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo operator", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary

## Features
- Added support for the modulo operator `%` in the CLI calculator.
- Users can now perform modulo operations using the `calc` command (e.g., `calc 10 % 3`).

## Tests
- Added a unit test to verify modulo calculation.
- Added an E2E test to verify the CLI supports the modulo operator.

## Plan
# Implementation Plan - Support Modulo Operator

This plan outlines the steps to add support for the modulo operator (`%`) to the existing CLI calculator.

## Proposed Changes

### 1. Update Core Logic (`src/cli.ts`)

- **Goal**: Enable the `calculate` function to perform modulo operations.
- **Steps**:
    - Update the `Operator` type definition to include `"%"`:
      ```typescript
      export type Operator = "+" | "-" | "*" | "/" | "%";
      ```
    - Update the `calculate` function to handle the `"%"` case in the `switch` statement:
      ```typescript
      case "%":
        return left % right;
      ```

### 2. Update CLI Interface (`src/index.ts`)

- **Goal**: Allow users to pass `%` as an operator in the `calc` command.
- **Steps**:
    - In the `calc` command definition, update the `choices` array for the `operator` positional argument to include `"%"`:
      ```typescript
      choices: ["+", "-", "*", "/", "%"] as const,
      ```
    - Update the type assertion for `operator` in the handler function:
      ```typescript
      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
      ```

### 3. Add Unit Tests (`tests/unit.test.ts`)

- **Goal**: Verify the correctness of the modulo logic.
- **Steps**:
    - Add a new test case to the `describe("calculate", ...)` block:
      ```typescript
      test("modulos", () => {
        expect(calculate(10, "%", 3)).toBe(1);
      });
      ```

### 4. Add E2E Tests (`tests/e2e.test.ts`)

- **Goal**: Verify that the CLI correctly accepts and processes the modulo operator.
- **Steps**:
    - Add a new test case to the `describe("cli", ...)` block:
      ```typescript
      test("calc supports modulo operator", async () => {
        const result = await runCli(["calc", "10", "%", "3"]);
        expect(result.exitCode).toBe(0);
        expect(result.stderr).toBe("");
        expect(result.stdout).toBe("1");
      });
      ```

## Verification Plan

After implementing the changes, run the following command to ensure all tests pass:

```bash
bun test
```