### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,5 +12,9 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    default: {
+      const exhaustiveCheck: never = operator;
+      throw new Error(`Unhandled operator: ${exhaustiveCheck}`);
+    }
   }
 }

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
Updated the hello text constant to "Hello, World!" and aligned the e2e expectation with the new output.

- Updated `src/cli.ts` to return the new hello message.
- Updated `tests/e2e.test.ts` to expect the new message.

## Plan
# Implementation Plan

## Goal
Update the CLI "hello" output to print `Hello, World!` instead of `Hello via Bun!`, and adjust tests accordingly.

## Relevant Files Reviewed
- `src/cli.ts` (defines `currentText` used by the hello command)
- `src/index.ts` (CLI wiring for `hello` and `calc` commands)
- `tests/e2e.test.ts` (end-to-end test expectation for hello output)
- `README.md` (basic usage; no output text referenced)

## Plan
1. Update `src/cli.ts` so `currentText` is exactly `"Hello, World!"`.
   - This value is printed by the `hello` command in `src/index.ts`.
2. Update the hello test in `tests/e2e.test.ts` to expect `"Hello, World!"`.
   - Keep trimming behavior in `runCli` in mind; the expected string should not include newline.
3. Optional verification (if running tests locally):
   - `bun test` to confirm `tests/e2e.test.ts` passes.
   - Alternatively, run only the e2e suite if needed.

## Notes
- No new libraries or external APIs are required.
- `src/index.ts` uses `currentText` directly; no additional code changes should be necessary beyond the constant and the test expectation.