### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
- Updated the CLI greeting constant to "Hello, World!".
- Aligned the e2e hello command expectation with the new greeting.
- Tests not run (per instructions).

## Plan
# Implementation Plan: Update CLI Greeting

## Goal
Update the CLI `hello` command to print `"Hello, World!"` instead of `"Hello via Bun!"`, and align tests with the new output.

## Relevant Files
- `src/cli.ts` (defines the current greeting text)
- `src/index.ts` (uses `currentText` for the `hello` command)
- `tests/e2e.test.ts` (asserts expected CLI output)

## Plan
1. **Update greeting constant**
   - In `src/cli.ts`, change `currentText` from `"Hello via Bun!"` to `"Hello, World!"`.
   - Keep the export name and usage unchanged so the CLI behavior stays consistent aside from the text.

2. **Adjust CLI output test**
   - In `tests/e2e.test.ts`, update the `hello prints the current text` expectation to match `"Hello, World!"`.
   - Ensure no other test expectations need changes (the `calc` command should remain unchanged).

3. **Sanity check (optional for developer)**
   - Run `bun test` to confirm the updated greeting passes the CLI test suite.

## Assumptions
- No other components depend on the exact greeting string beyond the `hello` command test.
- No external libraries or APIs are required for this change.