### PR TITLE
feat: support modulo operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ To run:
 bun run src/index.ts
 ```
 
+Supported operators: `+`, `-`, `*`, `/`, `%`.
+
 This project was created using `bun init` in bun v1.3.5. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ To run:
 bun run src/index.ts
 ```
 
-Supported operators: `+`, `-`, `*`, `/`, `%`.
+Supported operators: `+`, `-`, `*`, `/`, and `%`.
 
 This project was created using `bun init` in bun v1.3.5. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
- Added `%` support in the calculator core and CLI option validation.
- Expanded unit and CLI tests to cover modulo usage.
- Documented `%` as a supported operator in `README.md`.

Tests not run (per instructions).

## Plan
# Implementation Plan: Support Modulo Operator

## Summary
Add `%` support to the CLI calculator and core `calculate` function, plus tests and any documentation that describes supported operators.

## Files Reviewed
- `src/index.ts`
- `src/cli.ts`
- `tests/unit.test.ts`
- `tests/e2e.test.ts`
- `README.md`

## Plan
1. **Extend the operator type and logic**
   - Update `src/cli.ts` to include `%` in the `Operator` union type.
   - Add a `case "%"` branch in `calculate` returning `left % right`.
   - Ensure `calculate` still returns a `number` for all supported operators.

2. **Update CLI argument validation**
   - In `src/index.ts`, add `%` to the `choices` list for the `operator` positional argument.
   - Update the `operator` type annotation in the command handler to include `%`.

3. **Add/extend tests**
   - In `tests/unit.test.ts`, add a unit test for modulo (e.g., `calculate(10, "%", 3)` equals `1`).
   - In `tests/e2e.test.ts`, add a CLI test for `calc` with `%` (e.g., `calc 10 % 3` prints `1`).
   - Consider an edge case with negative operands if desired (optional; match existing test style).

4. **Update documentation (if applicable)**
   - If the CLI usage is documented elsewhere, update it to mention `%` as a supported operator (e.g., in `README.md` if a usage section is added later).

5. **Validation**
   - Run `bun test` to ensure unit and e2e tests pass.
   - Optionally run `bun run src/index.ts calc 10 % 3` to manually verify CLI output.

## Notes/Assumptions
- No external libraries are needed; the existing `yargs` setup already handles operator choices.
- Modulo uses JavaScript’s `%` operator semantics (remainder, not mathematical modulo).