### PR TITLE
feat: add modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,11 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
+    default: {
+      const unexpectedOperator: never = operator;
+      throw new Error(`Unsupported operator: ${unexpectedOperator}`);
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
## Summary
- Added `%` to the calculator operator type and runtime handling with a guarded default case.
- Updated CLI operator validation to accept modulo.
- Added unit and e2e coverage for modulo calculations.

## Tests
- Not run (per instructions).

## Plan
# Implementation Plan: Support Modulo Operator

## Goal
Add support for the modulo (`%`) operator in the calculator CLI, including type definitions, CLI validation, and tests.

## Relevant Files (reviewed)
- `src/cli.ts` (calculator logic and operator type)
- `src/index.ts` (CLI argument parsing and operator choices)
- `tests/unit.test.ts` (unit tests for `calculate`)
- `tests/e2e.test.ts` (CLI e2e tests)
- `README.md` (usage documentation; update if it documents operators)

## Plan
1. **Extend operator type and calculation logic**
   - Update `Operator` in `src/cli.ts` to include `%`.
   - Extend `calculate` switch to handle `%` with `left % right`.
   - Ensure the function remains exhaustive; consider a `default` case that throws if unexpected operator appears to keep type safety tight.

2. **Update CLI operator validation**
   - In `src/index.ts`, add `%` to the `choices` list for the `operator` positional.
   - Update the `operator` type assertion in the handler to include `%`.

3. **Add unit tests**
   - In `tests/unit.test.ts`, add a test case for modulo, e.g. `calculate(10, "%", 3) === 1`.
   - Optionally add edge case coverage like `calculate(10, "%", 5) === 0` if desired.

4. **Add CLI e2e test**
   - In `tests/e2e.test.ts`, add a new test to run `calc` with `%`, e.g. `calc 10 % 3` expecting output `1`.
   - Ensure the test verifies exit code `0` and empty stderr, matching existing style.

5. **Update documentation (if applicable)**
   - If `README.md` or any usage docs enumerate supported operators, include `%` in that list.

6. **Verification**
   - Run unit and e2e tests with `bun test`.
   - Manually validate CLI: `bun run src/index.ts calc 10 % 3` should print `1`.

## Notes / Assumptions
- No external libraries are required; `%` is native JavaScript/TypeScript.
- `%` should follow JavaScript modulo semantics (remainder), which can be negative if `left` is negative.