### PR TITLE
feat: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
- Updated `src/cli.ts` to print `Hello, World!` via `currentText`.
- Aligned `tests/e2e.test.ts` to expect the new output.
- Tests not run (per instruction).

## Plan
## Implementation Plan: Print "Hello, World!"

### Context and findings
- The CLI command `hello` prints the value of `currentText` from `src/cli.ts`, currently set to `"Hello via Bun!"`.
- The e2e test `tests/e2e.test.ts` asserts that `hello` prints `"Hello via Bun!"`.
- No external APIs or libraries are needed beyond the existing `yargs`/Bun setup; no documentation lookup required.

### Files to change
- `src/cli.ts`: update the `currentText` constant to the new required string.
- `tests/e2e.test.ts`: update the expected output to match the new string.
- (Optional) If any README or other documentation references the old text, update those references after confirming they exist (none found in `README.md`).

### Step-by-step plan
1. Update `src/cli.ts`:
   - Change `export const currentText = "Hello via Bun!";` to `export const currentText = "Hello, World!";`.
   - Keep the export name the same to avoid altering the CLI wiring in `src/index.ts`.
2. Update `tests/e2e.test.ts`:
   - In the `hello prints the current text` test, change the expected `stdout` from `"Hello via Bun!"` to `"Hello, World!"`.
3. Verify no other references to the old text remain:
   - Search the repository for `Hello via Bun!` to confirm only the updated locations remain.
4. (Optional) Run tests to validate behavior:
   - `bun test` to ensure both unit and e2e tests pass.

### Acceptance criteria
- Running `bun run src/index.ts hello` prints exactly `Hello, World!` with no extra output.
- `bun test` passes, including the updated e2e assertion.