### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
## Summary
- Added modulo (`%`) support to the calculator operator type, implementation, and CLI argument choices.
- Added unit and CLI integration coverage for modulo behavior.

## Tests
- Not run (per instructions)

## Plan
# Implementation Plan: Support Modulo Operator

## Goal
Add support for the modulo operator (`%`) alongside the existing arithmetic operators in the CLI calculator, including type definitions, CLI argument validation, and tests.

## Relevant Files Reviewed
- `src/cli.ts` (operator type + `calculate` implementation)
- `src/index.ts` (CLI command parsing and operator choices)
- `tests/unit.test.ts` (unit tests for `calculate`)
- `tests/e2e.test.ts` (CLI integration tests)
- `README.md` (project context, no operator details)

## Assumptions
- Modulo should follow JavaScript semantics (`left % right`).
- No additional validation (e.g., divide/mod by zero) is required unless existing behavior changes.

## Plan
1. **Extend the operator type**
   - Update `Operator` in `src/cli.ts` to include `%`.
   - This ensures type checking covers the new operator across the codebase.

2. **Implement modulo in `calculate`**
   - Add a `case "%"` branch in the `switch` inside `calculate` in `src/cli.ts`.
   - Return `left % right`.

3. **Expose modulo in the CLI parser**
   - Update the `choices` list for the `operator` positional in `src/index.ts` to include `%`.
   - Update the local `operator` type assertion to include `%` so TypeScript remains aligned with the new operator set.

4. **Add unit coverage**
   - In `tests/unit.test.ts`, add a new test case like `calculate(10, "%", 4)` expecting `2`.

5. **Add CLI coverage**
   - In `tests/e2e.test.ts`, add an integration test that runs `calc` with `%` (e.g., `10 % 4`) and asserts stdout is `2` with zero exit code and empty stderr.

6. **Verify**
   - Run `bun test` to ensure unit and e2e tests pass.

## Notes on External Libraries or APIs
- No new external libraries or APIs are required for this change.