### PR TITLE
feat: add support for modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo operator", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary

## Implemented Features
- Added support for the modulo operator (`%`) in the calculator CLI.
- Updated the `calc` command to accept `%` as a valid operator.
- Added unit tests for the modulo operator.

## Affected Files
- `src/cli.ts`: Updated `Operator` type and `calculate` function.
- `src/index.ts`: Updated `calc` command definition.
- `tests/unit.test.ts`: Added test case for modulo operator.

## Verification
- Verified manually using `bun run src/index.ts calc 10 % 3`, which returned `1`.
- Added a new test case `test("modulo", ...)` in `tests/unit.test.ts`.

## Plan
# Implementation Plan: Support Modulo Operator

## Goal
Add support for the modulo operator (`%`) to the existing calculator CLI.

## Affected Files
1. `src/cli.ts`
2. `src/index.ts`
3. `tests/unit.test.ts`

## Detailed Steps

### 1. Update Core Logic (`src/cli.ts`)
- **Action**: Modify the `Operator` type definition.
  - Add `| "%"` to the union type.
- **Action**: Update the `calculate` function.
  - Add a `case "%":` to the switch statement.
  - Return `left % right`.

### 2. Update CLI Interface (`src/index.ts`)
- **Action**: Update the `calc` command definition.
  - In the `operator` positional argument config, add `"%"` to the `choices` array.
  - Update the type casting for `operator` to include `%` (e.g., `as "+" | "-" | "*" | "/" | "%"`).

### 3. Add Unit Tests (`tests/unit.test.ts`)
- **Action**: Add a new test case within the `describe("calculate", ...)` block.
  - Test that `calculate(10, "%", 3)` returns `1`.
  - Example:
    ```typescript
    test("modulo", () => {
      expect(calculate(10, "%", 3)).toBe(1);
    });
    ```

## Verification
- Run `bun test` to ensure all tests pass, including the new modulo test case.
- Manually test the CLI:
  ```bash
  bun run src/index.ts calc 10 % 3
  ```