### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
## Summary
- Added `%` operator support in the calculator logic and CLI operator choices.
- Added unit and CLI tests covering modulo behavior.

## Testing
- Not run (per instructions).

## Plan
# Implementation Plan: Support Modulo Operator

## Goal
Add modulo (`%`) operator support to the CLI calculator alongside existing arithmetic operations.

## Scope and assumptions
- The calculator currently supports `+`, `-`, `*`, `/` via CLI and `calculate` helper.
- Modulo uses JavaScript `%` semantics on numbers (including non-integers), unless future constraints specify integers only.
- No external libraries are required; use built-in JS/TS functionality.

## Files reviewed
- `src/index.ts` (CLI command definitions and operator choices)
- `src/cli.ts` (operator type and calculation switch)
- `tests/unit.test.ts` (unit tests for `calculate`)
- `tests/e2e.test.ts` (CLI behavior tests)
- `README.md` (usage overview; optional documentation update)

## Plan
1. **Update operator definition**
   - In `src/cli.ts`, extend `Operator` union type to include `%`.
   - Add a `%` case in `calculate` that returns `left % right`.
   - Confirm the switch is exhaustive so TypeScript remains happy (consider adding a `default` with `never` if desired).

2. **Extend CLI operator choices**
   - In `src/index.ts`, add `%` to the `choices` array for the `operator` positional argument.
   - Update the `operator` type cast to include `%`.

3. **Add unit coverage**
   - In `tests/unit.test.ts`, add a test that `calculate(10, "%", 4)` returns `2`.
   - Optionally add a test for a non-integer case (e.g., `5.5 % 2`), if you want to document JS semantics explicitly.

4. **Add CLI coverage**
   - In `tests/e2e.test.ts`, add a new test invoking `calc 10 % 4` and asserting output `2`.
   - Ensure the CLI still prints only the number result (no extra formatting).

5. **(Optional) Update README**
   - If README includes operator descriptions in the future, mention modulo support there for discoverability.

## Validation
- Run `bun test` to ensure unit and e2e tests pass.
- Optionally run `bun run src/index.ts calc 10 % 4` to sanity-check CLI behavior.