### PR TITLE
feat: add modulo operator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ To run:
 bun run src/index.ts
 ```
 
+The CLI calculator supports `+`, `-`, `*`, `/`, and `%` operators.
+
 This project was created using `bun init` in bun v1.3.5. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
## Summary
- Added `%` support to the calculator logic and CLI operator validation.
- Added unit and CLI coverage for modulo calculations.
- Documented the supported operators.

## Tests
- Not run (per instructions).

## Plan
# Implementation Plan: Add Modulo Operator Support

## Goal
Add support for the modulo (`%`) operator in the CLI calculator alongside existing `+`, `-`, `*`, `/` operations.

## Understanding the Current Implementation
- `src/cli.ts` defines the `Operator` union type and `calculate` function with a `switch` for four operators.
- `src/index.ts` wires the CLI using `yargs`, restricting `operator` choices to `+`, `-`, `*`, `/` and calling `calculate`.
- `tests/unit.test.ts` covers `calculate` for the four existing operations.
- `tests/e2e.test.ts` covers the CLI for `hello` and a `calc` invocation using `+`.
- `README.md` only includes basic run/install instructions.

## Plan
1. **Expand the operator type and calculation logic**
   - Update `Operator` in `src/cli.ts` to include `"%"`.
   - Add a `case "%": return left % right;` in `calculate`.
   - Ensure the function still returns a `number` in all branches (keep the `switch` exhaustive).

2. **Allow the new operator in the CLI**
   - In `src/index.ts`, add `"%"` to the `choices` list for `operator`.
   - Update the local `operator` cast/type annotation to include `"%"`.

3. **Add/extend tests**
   - `tests/unit.test.ts`: add a `"modulo"` test (e.g., `calculate(10, "%", 3)` expects `1`).
   - `tests/e2e.test.ts`: add a CLI test (e.g., `calc 10 % 3` prints `1`) to ensure the CLI path accepts and processes `%`.

4. **Optional documentation update**
   - If the project expects user-facing docs, add a short note in `README.md` listing the supported operators, now including `%`.

5. **Verification steps (developer-run, not performed here)**
   - Run `bun test` to validate unit and e2e coverage.
   - Run `bun run src/index.ts calc 10 % 3` manually to confirm CLI behavior.

## Notes / Assumptions
- Modulo uses JavaScript’s `%` operator semantics (remainder) with `number` inputs.
- No external libraries are required; all changes are internal to existing TypeScript and tests.