### PR TITLE
feat: add support for modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo operator", async () => {
+    const result = await runCli(["calc", "5", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary

## Features Implemented
-   **Modulo Operator Support:** Added support for the modulo operator (`%`) to the calculator CLI.
    -   Updated `Operator` type definition in `src/cli.ts`.
    -   Implemented modulo logic in `calculate` function in `src/cli.ts`.
    -   Updated `yargs` configuration in `src/index.ts` to accept `%` as a valid operator.
    -   Updated type assertions in `src/index.ts`.

## Tests
-   Added a unit test for the modulo operator in `tests/unit.test.ts`.

## Plan
# Implementation Plan: Support Modulo Operator

This plan outlines the changes required to add support for the modulo operator (`%`) to the calculator CLI.

## 1. Update Core Logic (`src/cli.ts`)

The core calculation logic and type definitions need to be updated to recognize and handle the modulo operator.

**Steps:**
1.  **Update `Operator` Type:**
    -   Add `"%"` to the `Operator` union type.
    -   Current: `export type Operator = "+" | "-" | "*" | "/";`
    -   New: `export type Operator = "+" | "-" | "*" | "/" | "%";`

2.  **Update `calculate` Function:**
    -   Add a `case "%":` to the `switch` statement.
    -   Implement the logic to return `left % right`.

## 2. Update CLI Interface (`src/index.ts`)

The CLI argument parsing configuration needs to be updated to accept `%` as a valid operator.

**Steps:**
1.  **Update `yargs` Command Definition:**
    -   In the `calc` command builder, update the `choices` array for the `operator` positional argument.
    -   Add `"%"` to the list: `choices: ["+", "-", "*", "/", "%"] as const`.

2.  **Update Type Assertion:**
    -   Update the casting of `argv.operator` inside the handler function.
    -   Change `as "+" | "-" | "*" | "/"` to `as "+" | "-" | "*" | "/" | "%"` (or preferably import the `Operator` type from `./cli` to stay in sync).

## 3. Update Tests (`tests/unit.test.ts`)

Ensure the new functionality is covered by unit tests.

**Steps:**
1.  **Add Test Case:**
    -   Add a new test case within the `describe("calculate", ...)` block.
    -   Test that `calculate(10, "%", 3)` returns `1`.
    -   Example:
        ```typescript
        test("modulo", () => {
          expect(calculate(10, "%", 3)).toBe(1);
        });
        ```

## 4. Verification

1.  Run the tests using `bun test` to ensure all tests pass, including the new modulo test.
2.  (Optional) Manually test the CLI: `bun run src/index.ts calc 10 % 3` (Note: `%` might need escaping in some shells, e.g., `bun run src/index.ts calc 10 \% 3`).