### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
- Added `%` support in the calculator core and CLI operator validation.
- Added unit and e2e coverage for modulo calculations.
- Tests not run (per instruction).

## Plan
# Implementation plan: support modulo operator

## Understanding (current state)
- CLI entry (`src/index.ts`) defines `calc <left> <operator> <right>` with operator choices `+ - * /` and passes the operator to `calculate`.
- Core calculator (`src/cli.ts`) defines `Operator` union of `+ - * /` and `calculate` switch handling those four operations.
- Tests:
  - Unit tests (`tests/unit.test.ts`) cover +, -, *, /.
  - E2E test (`tests/e2e.test.ts`) covers `calc 2 + 3` output only.

## Plan
1. **Extend operator typing and CLI validation**
   - Update `Operator` type in `src/cli.ts` to include `%`.
   - Add a switch case for `%` in `calculate` returning `left % right`.
   - In `src/index.ts`, extend the yargs `choices` array for `operator` to include `%`, and update the operator type annotation in the handler to include `%`.
   - Consider whether modulo by zero should be allowed; align behavior with JS (`NaN` or `Infinity`), and document in tests if relevant.

2. **Update unit tests**
   - In `tests/unit.test.ts`, add a test case for modulo (e.g., `calculate(10, "%", 3)` should be `1`).
   - If edge behavior is desired (e.g., negative numbers or zero), add a focused test to lock it in; otherwise keep to a single positive integer example.

3. **Update CLI end-to-end coverage**
   - In `tests/e2e.test.ts`, add a new test invoking `calc` with `%` (e.g., `calc 10 % 3`) and assert stdout `1`, stderr empty, exit code `0`.

4. **Run and verify (optional but recommended)**
   - Run `bun test` to ensure unit and e2e coverage passes with the new operator.
   - Manually try `bun run src/index.ts calc 10 % 3` if you want a quick CLI sanity check.

## Notes / assumptions
- No external libraries or APIs are required; this is a local extension of the existing CLI and calculator.
- The modulo operator will follow JavaScript’s `%` semantics.