### PR TITLE
fix: update hello output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
- Updated `src/cli.ts` to print `Hello, World!` for the `hello` command.
- Updated `tests/e2e.test.ts` to expect the new greeting.
- Tests not run (per instructions).

## Plan
# Implementation Plan: Print "Hello, World!"

## Goal
Update the CLI so the `hello` command prints `Hello, World!` instead of `Hello via Bun!`, and align any tests/documentation with the new output.

## Relevant Files Reviewed
- `src/cli.ts` (defines `currentText` used by the CLI)
- `src/index.ts` (CLI wiring that prints `currentText`)
- `tests/e2e.test.ts` (asserts expected CLI output)
- `tests/unit.test.ts` (calculator tests; unaffected but reviewed for scope)
- `README.md` (usage info; check if it mentions the output)

## Planned Changes
1. **Update the source constant**
   - Edit `src/cli.ts` and change `currentText` from `"Hello via Bun!"` to `"Hello, World!"`.
   - Keep the export name and usage unchanged to avoid ripple effects in the CLI.

2. **Align end-to-end test expectations**
   - Edit `tests/e2e.test.ts` so the `hello prints the current text` test expects `"Hello, World!"`.
   - Leave the calculation test as-is.

3. **Check documentation for literal output**
   - Search `README.md` (and any other docs, if present) for the old string.
   - If found, update the text to `"Hello, World!"` to keep docs accurate.

4. **Sanity check**
   - Run the test suite (`bun test`) or at minimum the CLI test to confirm the updated output is reflected.
   - Optionally run `bun run src/index.ts hello` to verify manual output.

## Notes
- No external libraries or APIs are required for this change.
- The change is isolated to output text and test expectations.