### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
- Added `%` support across the calculator logic and CLI argument validation.
- Extended unit and E2E tests to cover modulo behavior.
- Tests not run (per instructions).

## Plan
# Implementation Plan: Add Modulo Operator Support

## Summary
Add `%` as a supported operator in the CLI and core calculator logic, plus unit and E2E coverage to verify behavior. No external libraries are required.

## Relevant Files Reviewed
- src/cli.ts
- src/index.ts
- tests/unit.test.ts
- tests/e2e.test.ts
- README.md

## Assumptions
- Modulo should follow JavaScript `%` semantics for numbers (including negatives and decimals) since the project already uses JS arithmetic directly.
- The CLI should accept `%` as a valid operator for the existing `calc` command and return the numeric result as a string.

## Detailed Steps
1. **Update operator type and calculation logic**
   - In `src/cli.ts`, extend the `Operator` union type to include `%`.
   - Add a `case "%":` branch in `calculate` that returns `left % right`.
   - Ensure the function remains exhaustive; consider adding a default `throw` for safety if desired by project conventions.

2. **Expose `%` in the CLI argument parser**
   - In `src/index.ts`, update the `choices` array for the `operator` positional argument to include `%`.
   - Update the `operator` type assertion to include `%` so TypeScript stays aligned with runtime validation.

3. **Add unit test coverage**
   - In `tests/unit.test.ts`, add a new test case such as `calculate(10, "%", 3)` expecting `1`.
   - If you want to validate edge cases, add one additional test for negative or decimal operands, but keep it consistent with existing test style.

4. **Add E2E CLI coverage**
   - In `tests/e2e.test.ts`, add a new test that runs `calc 10 % 3` and asserts stdout is `"1"`, stderr is empty, and exit code is `0`.

5. **(Optional) Documentation tweak**
   - If the README is meant to list supported operators, add `%` to that list. If not, skip.

## Acceptance Criteria
- CLI accepts `%` as a valid operator and returns the correct numeric result.
- Unit tests include at least one modulo case and pass.
- E2E tests include a modulo CLI invocation and pass.

## Testing Plan
- Run unit tests: `bun test tests/unit.test.ts`.
- Run E2E tests: `bun test tests/e2e.test.ts`.
- Optionally run the full test suite: `bun test`.