### PR TITLE
feat: add modulo operator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,10 @@ To run:
 bun run src/index.ts
 ```
 
+Example modulo usage:
+
+```bash
+bun run src/index.ts calc 10 % 3
+```
+
 This project was created using `bun init` in bun v1.3.5. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,9 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+    expect(calculate(5.5, "%", 2)).toBe(1.5);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
## Summary
- Added `%` operator support to the calculator core and CLI validation.
- Added unit/e2e coverage plus a README example for modulo usage.

## Tests
- Not run (per instructions).

## Plan
# Implementation plan: support modulo operator

## Overview
Add modulo (`%`) support to the calculator CLI and core `calculate` function, and extend tests to cover the new operator. No external libraries are required.

## Relevant files reviewed
- `src/index.ts` — CLI command definitions and operator choices.
- `src/cli.ts` — `Operator` union type and `calculate` implementation.
- `tests/unit.test.ts` — unit tests for arithmetic operations.
- `tests/e2e.test.ts` — CLI integration tests.
- `README.md` — general usage (no operator list yet).

## Assumptions
- Modulo is intended to follow JavaScript `%` semantics on numbers (including non-integers), consistent with other operators already supported.
- The CLI should accept `%` as an operator token alongside `+ - * /`.

## Detailed steps

1. **Update core operator type and calculation logic**
   - File: `src/cli.ts`
   - Extend `Operator` union to include `%`.
   - Add a `case "%": return left % right;` to the `calculate` switch.
   - Ensure the switch remains exhaustive for all operators.

2. **Allow `%` in CLI argument validation**
   - File: `src/index.ts`
   - Update the `choices` array for the `operator` positional to include `%`.
   - Update the local `operator` type assertion to include `%` so TypeScript aligns with the updated union.

3. **Add unit test for modulo**
   - File: `tests/unit.test.ts`
   - Add a test case such as `calculate(10, "%", 3) === 1`.
   - Optionally include a second test for non-integer behavior (e.g., `calculate(5.5, "%", 2) === 1.5`) if current expectations are purely numeric.

4. **Add CLI integration test for modulo**
   - File: `tests/e2e.test.ts`
   - Add a new test to run `calc 10 % 3` and assert stdout is `1` and stderr is empty.
   - Keep the same output formatting expectations (plain number string, no extra text).

5. **Documentation update (optional but recommended)**
   - File: `README.md`
   - Add a short example showing modulo usage, e.g. `bun run src/index.ts calc 10 % 3` → `1`.
   - This makes supported operators discoverable for users.

## Validation
- Run unit tests: `bun test tests/unit.test.ts`.
- Run e2e tests: `bun test tests/e2e.test.ts`.
- Manual smoke check: `bun run src/index.ts calc 10 % 3` should output `1`.

## Risks / Edge cases
- Modulo by zero follows JavaScript behavior (`NaN`), consistent with `/` handling; no additional validation is currently present.
- CLI parsing should handle `%` as a standalone argument; if shell interpretation is a concern in some environments, suggest quoting `%` in docs (e.g., `"%"`).