### PR TITLE
feat: add modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,11 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
+    default: {
+      const exhaustiveCheck: never = operator;
+      throw new Error(`Unknown operator: ${exhaustiveCheck}`);
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary
- Added `%` to the calculator operator union, calculation switch, and CLI operator choices.
- Added unit and e2e coverage for modulo behavior.

## Notes
- Tests not run (per instructions).

## Plan
# Implementation Plan: Support Modulo Operator

## Goal
Extend the CLI calculator to support the modulo (`%`) operator alongside `+`, `-`, `*`, `/`.

## Assumptions
- Use JavaScript/TypeScript `%` semantics (remainder for numbers, including non-integers).
- No new external libraries are required.

## Relevant Files Reviewed
- `src/cli.ts`
- `src/index.ts`
- `tests/unit.test.ts`
- `tests/e2e.test.ts`
- `README.md`

## Plan
1. **Update operator type and calculation logic**
   - In `src/cli.ts`, extend the `Operator` union type to include `%`.
   - Add a `case "%"` in `calculate` that returns `left % right`.
   - Confirm the `switch` still returns a number for all operators (consider adding a `default` that throws if you want explicit safety).

2. **Expose modulo in the CLI argument parsing**
   - In `src/index.ts`, extend the `choices` array in the `operator` positional to include `%`.
   - Update the `operator` type assertion to include `%` so TypeScript matches the new union.

3. **Add unit test coverage for modulo**
   - In `tests/unit.test.ts`, add a new test (e.g., `calculate(10, "%", 3) -> 1`).
   - Consider a second test for negative or non-integer inputs if you want to lock in JS `%` behavior (optional).

4. **Add CLI e2e coverage for modulo**
   - In `tests/e2e.test.ts`, add a `calc` invocation using `%` (e.g., `calc 10 % 3`) and assert stdout is `1` with empty stderr.

5. **Documentation (optional but recommended)**
   - If user-facing CLI usage is documented elsewhere, update it to mention `%` (not currently in `README.md`).

## Validation
- Run `bun test` to ensure both unit and e2e suites pass.
- Optionally run `bun run src/index.ts calc 10 % 3` to verify the CLI output manually.