### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
- Added `%` operator support in the calculator logic. (`src/cli.ts`)
- Allowed `%` in CLI validation and operator casting. (`src/index.ts`)
- Added modulo coverage in unit and CLI tests. (`tests/unit.test.ts`, `tests/e2e.test.ts`)

Tests not run (per instructions).

## Plan
# Implementation plan: support modulo operator

## Understanding (current behavior)
- `src/cli.ts` defines `Operator` as `+ - * /` and implements `calculate` with a switch on those four operators.
- `src/index.ts` wires a `calc <left> <operator> <right>` command via `yargs`, with `choices` limited to `+ - * /` and the operator type cast to the same union.
- Tests cover all four operations in `tests/unit.test.ts` and one CLI path in `tests/e2e.test.ts`.

## Plan
1. **Extend the operator type and calculation logic**
   - Update `Operator` in `src/cli.ts` to include `%`.
   - Add a `%` case in `calculate` that returns `left % right` (JavaScript remainder operator).
   - Consider (and document in code or tests) behavior when `right` is `0` if the project wants to define it; otherwise leave as JS default (`NaN` for `0 % 0`, `NaN` for `x % 0`).

2. **Update CLI argument validation**
   - In `src/index.ts`, add `%` to the `choices` array for the `operator` positional.
   - Update the operator type cast to include `%` so TypeScript stays aligned.

3. **Add unit coverage for modulo**
   - In `tests/unit.test.ts`, add a test like `calculate(10, "%", 3) === 1` (plus any extra edge case the team wants, e.g. negative numbers).

4. **Add CLI coverage for modulo**
   - In `tests/e2e.test.ts`, add a new CLI invocation such as `calc 10 % 3` and assert stdout is `1` and stderr empty.

5. **Validation**
   - Run `bun test` to confirm unit + e2e tests pass.
   - Optionally run `bun run src/index.ts calc 10 % 3` manually to spot-check CLI behavior.

## Files to edit
- `src/cli.ts` (operator union + calculate switch)
- `src/index.ts` (yargs choices + operator type cast)
- `tests/unit.test.ts` (new modulo unit test)
- `tests/e2e.test.ts` (new modulo CLI test)

## Assumptions and notes
- Modulo behavior should match JavaScript’s `%` operator semantics (remainder, not true mathematical modulo), which is consistent with using JS number operations for the other operators.
- No external libraries or APIs are required.