### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
<result>
- Added modulo operator support to calculator logic and CLI argument validation.
- Added unit and CLI end-to-end tests for `%`.
</result>

## Plan
# Implementation Plan: Add Modulo Operator Support

## Goal
Extend the calculator to support the modulo (`%`) operator alongside `+`, `-`, `*`, `/` across CLI parsing, core calculation logic, and tests.

## Scope and Assumptions
- The calculator is implemented in `src/cli.ts` with CLI wiring in `src/index.ts`.
- The operator set is currently restricted by TypeScript unions and `yargs` CLI `choices`.
- No external libraries are required for modulo; use the JavaScript `%` operator.
- Behavior mirrors JavaScript `%` semantics (including for negatives and non-integers), consistent with existing arithmetic operations.

## Files to Update
- `src/cli.ts`
- `src/index.ts`
- `tests/unit.test.ts`
- `tests/e2e.test.ts`

## Detailed Steps
1. **Expand the operator type and calculator logic**
   - Open `src/cli.ts`.
   - Update `Operator` union to include `%`.
     - Change `export type Operator = "+" | "-" | "*" | "/";` to include `"%"`.
   - Add a `case "%": return left % right;` to `calculate`'s `switch`.
   - Ensure TypeScript exhaustiveness remains satisfied (no default needed).

2. **Allow modulo in CLI argument validation**
   - Open `src/index.ts`.
   - In the `calc` command’s `operator` positional definition, add `%` to `choices` array.
     - Update `choices: ["+", "-", "*", "/"] as const` to include `"%"`.
   - Update the local `operator` type assertion to include `%`.
     - Change `const operator = argv.operator as "+" | "-" | "*" | "/";` to include `"%"`.

3. **Add unit tests for modulo**
   - Open `tests/unit.test.ts`.
   - Add a new test case for modulo behavior, e.g. `calculate(10, "%", 3)` should return `1`.
   - Consider an additional test for non-integer inputs only if needed (not required for parity with other operations).

4. **Add CLI end-to-end coverage for modulo**
   - Open `tests/e2e.test.ts`.
   - Add a new test that runs: `calc 10 % 3` and asserts stdout is `1` with exit code `0` and empty stderr.

5. **Validation (developer-run)**
   - Run unit and e2e tests: `bun test`.
   - Manually sanity-check CLI: `bun run src/index.ts calc 10 % 3` should print `1`.

## Notes / Edge Cases
- Modulo by zero will produce `NaN` in JavaScript; no extra validation is added to match existing division-by-zero behavior (currently unhandled).
- If future requirements need mathematical modulo for negatives, adjust logic accordingly; not requested here.