### PR TITLE
feat: add modulo operator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,10 @@ To run:
 bun run src/index.ts
 ```
 
+Calculator supports `+`, `-`, `*`, `/`, `%` operators. For `%`, quote or escape in shells:
+
+```bash
+bun run src/index.ts calc 10 "%" 4
+```
+
 This project was created using `bun init` in bun v1.3.5. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
<result>
## Summary
- Added modulo support to the calculator operator type, CLI parsing, and calculation logic.
- Added unit and CLI tests to cover `%` behavior.
- Documented supported operators and how to quote `%` in the README.

## Testing
- Not run (per instructions).
</result>

## Plan
# Implementation Plan: Support Modulo Operator

## Goal
Add modulo (`%`) support to the calculator CLI alongside `+`, `-`, `*`, `/`.

## Relevant Files Reviewed
- `src/index.ts` (CLI wiring, yargs operator choices)
- `src/cli.ts` (operator type + calculate switch)
- `tests/unit.test.ts` (unit coverage for operations)
- `tests/e2e.test.ts` (CLI behavior)
- `README.md` (basic usage; no op list currently)

## Assumptions
- Modulo should use JavaScript’s `%` operator semantics (remainder, not mathematical modulo for negatives).
- No new external libraries are required.

## Plan
1. **Extend operator typing and calculation logic**
   - Update `Operator` in `src/cli.ts` to include `%`.
   - Add a `%` case in `calculate` that returns `left % right`.
   - Ensure the switch remains exhaustive (TypeScript should now accept `%`).

2. **Expose modulo in CLI argument validation**
   - In `src/index.ts`, add `%` to the `choices` array for the `operator` positional.
   - Update the `operator` type assertion to include `%`.

3. **Add/adjust tests**
   - In `tests/unit.test.ts`, add a test case for modulo (e.g., `calculate(10, "%", 4)` should be `2`).
   - In `tests/e2e.test.ts`, add a CLI test for modulo output (e.g., `calc 10 % 4` returns `2`).
   - Keep existing tests unchanged; ensure the new tests assert no stderr and exit code 0 for the CLI.

4. **(Optional) Documentation touch-up**
   - If desired, add a brief note in `README.md` or usage docs about supported operators including `%`.

## Verification
- Run unit tests: `bun test tests/unit.test.ts`.
- Run e2e tests: `bun test tests/e2e.test.ts`.
- Manual check: `bun run src/index.ts calc 10 % 4` should print `2`.

## Notes
- No external API or library changes required.
- `%` is a special character in shells; when documenting CLI usage, remind users to quote or escape it if needed (e.g., `calc 10 "%" 4`).