### PR TITLE
feat: add modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
<result>
- Added `%` to calculator operator types and CLI validation.
- Implemented modulo calculation behavior.
- Added unit and CLI e2e coverage for modulo.
</result>

## Plan
## Implementation plan: support modulo operator

### Assumptions
- The calculator is intentionally minimal and only supports binary operations on two numbers.
- Modulo should behave like JavaScript’s `%` operator (including for non-integers), since the existing arithmetic operations map directly to JavaScript operators.
- CLI input will pass `%` as the operator string, similar to the existing `+`, `-`, `*`, `/`.

### Relevant files to update
- `src/cli.ts` (core operator type and calculation logic).
- `src/index.ts` (CLI argument validation and operator choices).
- `tests/unit.test.ts` (unit coverage for modulo).
- `tests/e2e.test.ts` (CLI coverage for modulo).

### Detailed steps
1. **Extend operator type and calculation logic**
   - In `src/cli.ts`, update the `Operator` union type to include `%`.
   - Add a new `case "%":` branch in `calculate` that returns `left % right`.
   - Ensure the function still returns a number for all operators.

2. **Update CLI operator validation**
   - In `src/index.ts`, update the `choices` list for the `operator` positional argument to include `%`.
   - Update the local `operator` type annotation to include `%` so TypeScript recognizes the new operator.

3. **Add unit test for modulo**
   - In `tests/unit.test.ts`, add a new test (e.g., "modulo") that verifies `calculate(10, "%", 3)` returns `1`.
   - Keep the test suite structure consistent with existing tests.

4. **Add CLI end-to-end test for modulo**
   - In `tests/e2e.test.ts`, add a new test verifying `calc 10 % 3` returns `1` with no stderr and exit code `0`.
   - Use the existing `runCli` helper to mirror other CLI tests.

5. **(Optional) Update documentation**
   - If `README.md` documents supported operators, add `%` to that list.
   - If no operator list exists, skip this step.

### Verification
- Run unit tests: `bun test tests/unit.test.ts`.
- Run e2e tests: `bun test tests/e2e.test.ts`.
- Optional full run: `bun test`.

### External libraries/APIs
- None required; use native JavaScript `%` operator.