### PR TITLE
feat: add modulo operator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,10 @@ To run:
 bun run src/index.ts
 ```
 
+Example:
+
+```bash
+bun run src/index.ts calc 10 % 3
+```
+
 This project was created using `bun init` in bun v1.3.5. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
<result>
- Added `%` support to calculator logic and CLI operator choices in `src/cli.ts` and `src/index.ts`.
- Added unit and CLI E2E tests covering modulo behavior in `tests/unit.test.ts` and `tests/e2e.test.ts`.
- Documented modulo usage example in `README.md`.
</result>

## Plan
## Implementation Plan: Add Modulo Operator Support

### Scope and assumptions
- The CLI already supports `calc <left> <operator> <right>` for `+`, `-`, `*`, `/` and should be extended to support `%`.
- No new external libraries are required; the modulo operator is native in JavaScript/TypeScript.
- Tests should be updated/added to cover modulo in both unit and CLI E2E tests.

### Files reviewed
- `src/cli.ts` (calculator logic + operator type)
- `src/index.ts` (CLI command and operator choices)
- `tests/unit.test.ts` (unit coverage for calculate)
- `tests/e2e.test.ts` (CLI behavior)
- `README.md` (usage overview)

### Planned changes
1. **Update operator type and calculator logic**
   - In `src/cli.ts`, extend `Operator` to include `%`.
   - Add a `case "%"` in `calculate` that returns `left % right`.
   - Ensure the function remains exhaustive for all operators.

2. **Expand CLI operator choices**
   - In `src/index.ts`, add `%` to the `choices` list for the `operator` positional.
   - Update the inferred operator type in the handler to include `%`.

3. **Add unit test coverage**
   - In `tests/unit.test.ts`, add a test like `calculate(10, "%", 3)` expecting `1`.
   - Consider including another test for negative or non-integer inputs if desired; keep consistent with existing test style.

4. **Add CLI E2E coverage**
   - In `tests/e2e.test.ts`, add a `calc` test using `%` (e.g., `10 % 3` -> `1`).
   - Validate that stdout is only the numeric result and stderr is empty, consistent with other tests.

5. **(Optional) Update documentation**
   - If desired, extend `README.md` with a short example showing `%` usage.
   - Keep it minimal, matching current README style.

### Validation steps
- Run unit tests: `bun test tests/unit.test.ts`.
- Run E2E tests: `bun test tests/e2e.test.ts`.
- Or run all tests: `bun test`.

### Notes
- No external APIs or libraries are needed; modulo uses native JavaScript operator `%`.
- If modulo by zero occurs, JavaScript returns `NaN`; decide whether to document or leave as-is (current behavior for division by zero is also `Infinity`/`-Infinity`).