### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Implemented modulo support across the calculator by extending the operator union and CLI argument validation so `%` is accepted and computed via the core switch in `src/cli.ts` and `src/index.ts`. Added unit and CLI tests for a basic modulo case to cover the new operator in `tests/unit.test.ts` and `tests/e2e.test.ts`.

- Updated operator choices and logic: `src/cli.ts`, `src/index.ts`
- Added modulo coverage: `tests/unit.test.ts`, `tests/e2e.test.ts`
- Tests not run (per instructions).

## Plan
# Implementation Plan: Add Modulo Operator Support

## Goal
Add modulo (`%`) support to the calculator CLI and core calculation logic, alongside the existing `+ - * /` operators. Update type definitions, CLI argument validation, and tests to cover the new operator.

## Relevant Files (reviewed)
- `src/cli.ts` (core `calculate` function and operator type)
- `src/index.ts` (CLI command, operator choices, argument parsing)
- `tests/unit.test.ts` (unit coverage for `calculate`)
- `tests/e2e.test.ts` (CLI behavior test)
- `README.md` (project overview; no current operator list but check for future doc changes)

## Assumptions
- Modulo behavior follows JavaScript’s `%` operator semantics for numbers (including negatives and decimals). If different semantics are required (e.g., Euclidean modulo), clarify before implementation.

## Plan
1) **Extend the operator type and calculation logic**
   - Update `src/cli.ts`:
     - Extend `Operator` union to include `"%"`.
     - Add a `case "%"` in `calculate` returning `left % right`.
     - Ensure the `switch` remains exhaustive (optionally add a default that throws for impossible operators if desired).

2) **Expose modulo in the CLI argument validation**
   - Update `src/index.ts`:
     - Add `"%"` to the `choices` array for the `operator` positional.
     - Update the `operator` type assertion to include `"%"`.
     - Confirm command description remains accurate (optional: mention modulo in the help text if desired).

3) **Add unit test coverage for modulo**
   - Update `tests/unit.test.ts`:
     - Add a new test case, e.g. `calculate(10, "%", 4)` returns `2`.
     - Consider adding a negative or non-integer case only if behavior expectations are defined.

4) **Add end-to-end CLI coverage for modulo**
   - Update `tests/e2e.test.ts`:
     - Add a test invoking `calc 10 % 4` and assert output is `2` with zero stderr and exit code `0`.

5) **(Optional) Documentation clarity**
   - If you want README to list supported operators, add `"%"` to that list. Otherwise leave as-is.

6) **Verification**
   - Run test suite: `bun test`.
   - If tests are split, run both unit and e2e as configured by Bun defaults.

## Notes on External Dependencies
- No new external libraries or APIs are required. Existing logic uses core TypeScript/Bun and `yargs`.