### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary
- Added `%` support to the calculator core and CLI operator choices.
- Updated CLI typing to reuse the shared `Operator` type.
- Added unit and e2e coverage for modulo operations.

# Testing
- Not run (per instructions).

## Plan
# Implementation Plan: Support Modulo Operator

## Goal
Add support for the modulo operator (`%`) alongside the existing arithmetic operators in the CLI and core calculator logic, and extend tests to cover it.

## Scope and Assumptions
- The calculator currently supports `+`, `-`, `*`, `/` for both CLI parsing and the `calculate` function.
- Modulo should follow JavaScript `%` semantics for numbers.
- No external libraries are required.

## Relevant Files Reviewed
- `src/cli.ts` (operator type and `calculate` implementation)
- `src/index.ts` (CLI command definition and operator choices)
- `tests/unit.test.ts` (unit coverage for `calculate`)
- `tests/e2e.test.ts` (CLI integration tests)
- `README.md` (project context; no change required)

## Detailed Plan
1. **Update operator type and calculation logic**
   - File: `src/cli.ts`
   - Add `%` to the `Operator` union type.
   - Extend the `switch` in `calculate` with a `%` case that returns `left % right`.
   - Ensure the function still returns a `number` for all cases.

2. **Allow `%` in CLI argument parsing**
   - File: `src/index.ts`
   - Add `%` to the `choices` array for the `operator` positional argument.
   - Update the inferred operator type in the handler to include `%` (align with `Operator`).

3. **Add unit test coverage for modulo**
   - File: `tests/unit.test.ts`
   - Add a test case (e.g., `calculate(10, "%", 4)` expected to be `2`).
   - Keep tests consistent with existing style (`describe`/`test` from `bun:test`).

4. **Add CLI e2e test for modulo**
   - File: `tests/e2e.test.ts`
   - Add a CLI test for `calc` with `%`, verifying output is only the numeric result.
   - Example: `runCli(["calc", "10", "%", "4"])` expects stdout `"2"`.

5. **(Optional) Update documentation**
   - File: `README.md`
   - If the project documents supported operators elsewhere, add `%` to that list. (Currently no explicit operator list is documented.)

## Validation Steps
- Run unit tests: `bun test tests/unit.test.ts`.
- Run e2e tests: `bun test tests/e2e.test.ts`.
- Manual CLI check: `bun run src/index.ts calc 10 % 4` should print `2`.

## Notes
- `%` in CLI arguments should be passed as a literal character; no shell escaping is needed in typical shells when used as a standalone argument.
- No changes to dependencies or external APIs are required.