### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added `%` support to the core calculator and CLI parsing, and covered it with unit and e2e tests without changing existing operator behavior.

**Change summary**
- Extended `Operator` and `calculate` to handle modulo in `src/cli.ts`
- Allowed `%` in CLI operator choices and typing in `src/index.ts`
- Added modulo assertions in `tests/unit.test.ts` and `tests/e2e.test.ts`

**Tests**
- Not run (per instructions)

**Next steps**
1. Run `bun test`

## Plan
**Goal**
Add modulo (`%`) support to the calculator CLI and core calculation logic, including tests, without altering existing behavior for + - * /.

**Relevant files reviewed**
- src/cli.ts
- src/index.ts
- tests/unit.test.ts
- tests/e2e.test.ts
- README.md

**Implementation plan**
1) Extend the operator type and calculation logic
- Update `Operator` in `src/cli.ts` to include `%`.
- Add a `case "%"` branch in `calculate` that returns `left % right`.
- Keep behavior consistent with existing operations (no new validation; JS modulo semantics, including negative numbers and modulo-by-zero producing `NaN`).

2) Update CLI argument validation and typing
- In `src/index.ts`, extend the `choices` list for `operator` to include `%`.
- Update the `operator` type assertion to include `%` so type checking matches the new operator.

3) Add/extend tests
- In `tests/unit.test.ts`, add a new test case for modulo (e.g., `calculate(10, "%", 3) -> 1`).
- In `tests/e2e.test.ts`, add a CLI test that runs `calc` with `%` and verifies stdout is the expected result, stderr empty, exit code 0.
- Consider a modulo edge-case test only if needed for clarity; otherwise keep parity with existing test depth.

4) (Optional) Update documentation
- If you want CLI usage spelled out, update `README.md` or add an example showing `%` in the `calc` command. This is optional since current README does not document operators.

**Notes/assumptions**
- No external libraries or APIs are required; this stays within built-in JS/Bun features.
- The modulo operator should follow JavaScript `%` semantics to match existing arithmetic behavior and avoid introducing validation not present for division.

**Suggested validation**
- Run unit tests: `bun test`.
- Run the CLI example: `bun run src/index.ts calc 10 % 3` (shell may require quoting `%` depending on environment).