### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Implemented modulo support in the CLI calculator by extending the operator type, calculation logic, and CLI argument validation, and added unit/e2e coverage for `%`.

- Updated operator union and switch handling in `src/cli.ts`.
- Allowed `%` in CLI operator choices and casting in `src/index.ts`.
- Added modulo tests in `tests/unit.test.ts` and `tests/e2e.test.ts`.

Tests not run (per instruction).

## Plan
# Implementation plan: add modulo operator support

## Goal
Add `%` (modulo) as a supported arithmetic operator for the CLI calculator, including type support and tests, without changing behavior for existing operators.

## Scope and assumptions
- CLI currently supports `+ - * /` and delegates math to `calculate` in `src/cli.ts`.
- No external libraries are needed; `%` is a native JavaScript operator.
- Update tests to cover the new operator in both unit and e2e coverage.

## Relevant files reviewed
- `src/index.ts` (CLI wiring and operator choices)
- `src/cli.ts` (operator type and `calculate` implementation)
- `tests/unit.test.ts` (unit coverage for arithmetic)
- `tests/e2e.test.ts` (CLI behavior expectations)

## Plan
1. **Extend operator type and calculation logic**
   - File: `src/cli.ts`
   - Add `%` to the `Operator` union type.
   - Add a `case "%": return left % right;` to the `calculate` switch.
   - Ensure the function still returns a `number` for all operators.

2. **Expose modulo in CLI argument validation**
   - File: `src/index.ts`
   - Add `%` to the `choices` list for the `operator` positional argument.
   - Update the inferred operator type for `argv.operator` to include `%`.

3. **Add unit test coverage for modulo**
   - File: `tests/unit.test.ts`
   - Add a test like `calculate(10, "%", 3)` expects `1`.
   - Consider an additional test with a negative or non-integer input if desired for clarity (optional).

4. **Add end-to-end CLI test for modulo**
   - File: `tests/e2e.test.ts`
   - Add a test that runs `calc 10 % 3` and expects `1` with empty stderr and exit code `0`.

5. **Optional verification (developer-run)**
   - Run `bun test` to confirm unit/e2e coverage for `%` alongside existing operators.

## Notes
- No external API or documentation is required because modulo is part of JavaScript's built-in arithmetic operators.
- Keep output formatting unchanged: CLI should still print only the numeric result.