### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,9 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
+    default:
+      throw new Error(`Unsupported operator: ${operator}`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "7", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("3");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(7, "%", 4)).toBe(3);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo support end-to-end with an explicit unsupported-operator guard in `src/cli.ts` and CLI parsing updates in `src/index.ts`, plus unit and CLI coverage.
- `src/cli.ts`: extend `Operator` with `%`, implement modulo behavior, and throw on unsupported operators.
- `src/index.ts`: allow `%` in CLI choices and operator typing for `calc`.
- `tests/unit.test.ts`: add a modulo calculation assertion.
- `tests/e2e.test.ts`: add a `calc` modulo integration case.

Testing not run (per instructions).

Next steps:
1) `bun test`

## Plan
# Implementation Plan: Support Modulo Operator

## Goal
Add modulo (`%`) support to the calculator CLI alongside the existing `+`, `-`, `*`, `/` operators, including CLI parsing and tests.

## Relevant Files Reviewed
- `src/cli.ts` (operator type and calculation logic)
- `src/index.ts` (yargs CLI command and operator choices)
- `tests/unit.test.ts` (unit tests for `calculate`)
- `tests/e2e.test.ts` (CLI integration tests)
- `README.md` (project usage docs; no operator list but note for potential update)

## Assumptions
- Modulo behavior should follow JavaScript’s `%` operator semantics (e.g., `7 % 4 === 3`, `-7 % 4 === -3`, `7 % 0 === NaN`).
- No additional error handling is requested for division/modulo by zero beyond JS defaults.

## Plan
1. **Update core operator type and calculation logic**
   - In `src/cli.ts`, extend `Operator` to include `%`.
   - Add a `case "%": return left % right;` to `calculate`.
   - (Optional but recommended) add a `default` case that throws a descriptive error for unsupported operators to prevent undefined returns.

2. **Expose modulo in the CLI interface**
   - In `src/index.ts`, add `%` to the `choices` array for the `operator` positional argument.
   - Update the `operator` type cast in the command handler to include `%`.

3. **Add unit test coverage**
   - In `tests/unit.test.ts`, add a new test (e.g., `expect(calculate(7, "%", 4)).toBe(3);`).
   - (Optional) add a negative-number or zero case if behavior should be codified.

4. **Add CLI integration test**
   - In `tests/e2e.test.ts`, add a test like `runCli(["calc", "7", "%", "4"])` and assert output `"3"`.

5. **Documentation (optional)**
   - If desired, update `README.md` to mention modulo support in any usage examples or operator lists.

## Test Plan
- Run `bun test` to cover both unit and e2e tests.
- (Optional) Run `bun run src/index.ts calc 7 % 4` to confirm CLI behavior manually.

## External Libraries / APIs
- None required for modulo support.