### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,9 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
+    default:
+      throw new Error(`Unsupported operator: ${operator}`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
- Added `%` operator support and explicit unsupported-operator error handling in `src/cli.ts`.
- Exposed `%` in CLI operator choices/types and added modulo coverage in `tests/e2e.test.ts` and `tests/unit.test.ts`.

Tests not run (per instructions).

## Plan
# Implementation Plan: Support Modulo Operator

## Goal
Add modulo (`%`) operator support to the calculator logic and CLI so users can compute remainders alongside the existing `+`, `-`, `*`, and `/` operations.

## Assumptions
- Modulo should follow JavaScript/TypeScript `%` semantics for numbers (including floats and negatives).
- No new external libraries are needed.

## Files Reviewed (Current Behavior)
- `src/cli.ts` defines `Operator` as `+ | - | * | /` and implements `calculate` via a `switch` without a default branch.
- `src/index.ts` wires the CLI using `yargs`, allowing only `+ - * /` choices and typing the operator as `+ | - | * | /`.
- `tests/unit.test.ts` covers four operators via `calculate`.
- `tests/e2e.test.ts` covers `hello` and a single `calc` invocation.

## Plan
1. **Extend operator type and calculation logic**
   - Update `Operator` in `src/cli.ts` to include `%`.
   - Add a `case "%"` in `calculate` that returns `left % right`.
   - Consider adding a `default` branch that throws a clear error for unknown operators to keep behavior explicit if future operators are added.

2. **Expose modulo in the CLI contract**
   - In `src/index.ts`, expand the `choices` array for the `operator` positional argument to include `%`.
   - Update the `operator` type assertion to include `%` so TypeScript aligns with the new operator.

3. **Add unit coverage for modulo**
   - In `tests/unit.test.ts`, add a test case verifying modulo behavior (e.g., `calculate(10, "%", 4)` returns `2`).
   - If negative or float behavior matters, add an additional test that reflects the desired semantics (optional but clarifies intent).

4. **Add CLI (e2e) coverage for modulo**
   - In `tests/e2e.test.ts`, add a `calc` invocation using `%` (e.g., `calc 10 % 4`) and assert output is `2` with no stderr.

5. **Validation steps (manual or CI)**
   - Run `bun test` to ensure unit and e2e coverage passes.
   - Run `bun run src/index.ts calc 10 % 4` to confirm CLI behavior manually if desired.

## Notes
- No external APIs or libraries are required for this change; it is a pure arithmetic update leveraging built-in JavaScript `%`.