### PR TITLE
feat: add support for modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc with modulo prints only the number result", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary: Support Modulo Operator

## Overview

Added support for the modulo operator (`%`) to the calculator CLI application, extending the existing arithmetic operations.

## Files Modified

### src/cli.ts
- Added `"%"` to the `Operator` type union
- Added `case "%": return left % right;` to the `calculate()` switch statement

### src/index.ts
- Added `"%"` to the yargs `choices` array for the operator positional argument
- Updated the type assertion to include `"%"`

### tests/unit.test.ts
- Added unit test for modulo operation: `expect(calculate(10, "%", 3)).toBe(1)`

### tests/e2e.test.ts
- Added E2E test for modulo CLI usage with args `["calc", "10", "%", "3"]`

## Commit

```
feat: add support for modulo operator

Add modulo operator (%) to the calculator CLI, extending arithmetic
operations to include remainder calculations.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
```

## Branch

Pushed to `o-agents/issue-4-20260114-110900_0805-2`

## Plan
# Implementation Plan: Support Modulo Operator

## Overview

Add support for the modulo operator (`%`) to the existing calculator CLI application. This feature extends the current arithmetic operations (`+`, `-`, `*`, `/`) to include modulo calculations.

## Current State

The calculator currently supports four arithmetic operations:
- Addition (`+`)
- Subtraction (`-`)
- Multiplication (`*`)
- Division (`/`)

The implementation consists of:
- **src/cli.ts**: Contains the `Operator` type definition and `calculate()` function
- **src/index.ts**: CLI entry point using yargs for argument parsing
- **tests/unit.test.ts**: Unit tests for the `calculate()` function
- **tests/e2e.test.ts**: End-to-end CLI tests

## Implementation Steps

### Step 1: Update the Operator Type (src/cli.ts:3)

**File:** `src/cli.ts`

**Current code:**
```typescript
export type Operator = "+" | "-" | "*" | "/";
```

**Modified code:**
```typescript
export type Operator = "+" | "-" | "*" | "/" | "%";
```

**Rationale:** The `Operator` type union must include `"%"` to allow modulo as a valid operator input.

---

### Step 2: Add Modulo Case to Calculate Function (src/cli.ts:5-16)

**File:** `src/cli.ts`

**Current code:**
```typescript
export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
  }
}
```

**Modified code:**
```typescript
export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
    case "%":
      return left % right;
  }
}
```

**Rationale:** Add a new case for the modulo operator using JavaScript's `%` operator.

**Note:** JavaScript's `%` operator is a remainder operator. For positive numbers, it behaves like mathematical modulo. For negative numbers, it preserves the sign of the dividend (e.g., `-7 % 3 = -1`). This is consistent behavior with the existing division operator, which also follows JavaScript's standard behavior.

---

### Step 3: Update CLI Operator Choices (src/index.ts:25)

**File:** `src/index.ts`

**Current code:**
```typescript
.positional("operator", {
  type: "string",
  choices: ["+", "-", "*", "/"] as const,
  demandOption: true,
})
```

**Modified code:**
```typescript
.positional("operator", {
  type: "string",
  choices: ["+", "-", "*", "/", "%"] as const,
  demandOption: true,
})
```

**Rationale:** The yargs `choices` array must include `"%"` to accept it as a valid command-line argument.

---

### Step 4: Update Operator Type Assertion (src/index.ts:35)

**File:** `src/index.ts`

**Current code:**
```typescript
const operator = argv.operator as "+" | "-" | "*" | "/";
```

**Modified code:**
```typescript
const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
```

**Rationale:** The type assertion must match the updated `Operator` type to maintain type safety.

---

### Step 5: Add Unit Test for Modulo (tests/unit.test.ts)

**File:** `tests/unit.test.ts`

**Add the following test case inside the `describe("calculate", ...)` block after the divides test (after line 19):**

```typescript
test("modulo", () => {
  expect(calculate(10, "%", 3)).toBe(1);
});
```

**Rationale:** Unit test coverage for the new modulo operation. The test validates that `10 % 3 = 1`.

---

### Step 6: Add E2E Test for Modulo (tests/e2e.test.ts)

**File:** `tests/e2e.test.ts`

**Add the following test case inside the `describe("cli", ...)` block after the calc test (after line 39):**

```typescript
test("calc with modulo prints only the number result", async () => {
  const result = await runCli(["calc", "10", "%", "3"]);
  expect(result.exitCode).toBe(0);
  expect(result.stderr).toBe("");
  expect(result.stdout).toBe("1");
});
```

**Rationale:** End-to-end test to verify the modulo operator works correctly through the CLI interface.

---

## Files to Modify

| File | Changes |
|------|---------|
| `src/cli.ts` | Add `"%"` to Operator type, add modulo case to switch statement |
| `src/index.ts` | Add `"%"` to yargs choices array and type assertion |
| `tests/unit.test.ts` | Add unit test for modulo operation |
| `tests/e2e.test.ts` | Add E2E test for modulo CLI usage |

## Verification

After implementation, run the following commands to verify:

```bash
# Run unit tests
bun test tests/unit.test.ts

# Run E2E tests
bun test tests/e2e.test.ts

# Manual verification
bun run src/index.ts calc 10 % 3
# Expected output: 1

bun run src/index.ts calc 17 % 5
# Expected output: 2
```

## Edge Cases to Consider

1. **Division by zero behavior**: `10 % 0` returns `NaN` in JavaScript (not an error). This is consistent with the existing `/` operator behavior where `10 / 0` returns `Infinity`.

2. **Negative numbers**: JavaScript's `%` is a remainder operator:
   - `-7 % 3` returns `-1`
   - `7 % -3` returns `1`
   - `-7 % -3` returns `-1`

3. **Floating-point numbers**: Modulo works with decimals (e.g., `5.5 % 2` returns `1.5`).

## External Dependencies

No additional external libraries or APIs are required. The implementation uses:
- JavaScript's built-in `%` (remainder) operator
- Existing yargs library (already installed, v18.0.0)
- Bun's built-in test framework (already in use)