### PR TITLE
feat: add modulo operator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ To run:
 bun run src/index.ts
 ```
 
+The `calc` command supports `+`, `-`, `*`, `/`, and `%` operators.
+
 This project was created using `bun init` in bun v1.3.5. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Implemented modulo support across the CLI and core calculator, extending operator handling, CLI validation, and the switch logic in `calculate`. Added unit and e2e coverage for `%`, and noted supported operators in the README.

- Updated operator union and `calculate` to handle `%` in `src/cli.ts`.
- Exposed `%` in CLI parsing in `src/index.ts`.
- Added modulo unit and e2e tests in `tests/unit.test.ts` and `tests/e2e.test.ts`.
- Documented supported operators in `README.md`.

Tests not run (per instructions).

## Plan
**Goal**
- Add modulo (`%`) support to the calculator CLI and core `calculate` helper, with tests covering the new operator.

**Scope (Files Reviewed)**
- `src/cli.ts` (operator type and `calculate` implementation)
- `src/index.ts` (CLI command definition and operator choices)
- `tests/unit.test.ts` (unit tests for `calculate`)
- `tests/e2e.test.ts` (CLI behavior)
- `README.md` (usage/overview; currently minimal)

**Assumptions**
- Modulo should use JavaScript’s `%` operator semantics for numbers (including negatives and non-integers), consistent with other arithmetic behavior.
- No additional external libraries are required.

**Implementation Plan**
1) **Extend operator typing**
   - Update `Operator` in `src/cli.ts` to include `%`.
   - Ensure any type assertions or unions in `src/index.ts` include `%`.

2) **Implement modulo in calculate**
   - Add a `case "%": return left % right;` branch in `src/cli.ts`.
   - Keep the switch exhaustive for the updated `Operator` union.

3) **Expose modulo in CLI parsing**
   - In `src/index.ts`, update the `choices` array for the `operator` positional to include `%`.
   - Update the `operator` type assertion to include `%` so TypeScript matches runtime validation.

4) **Add unit coverage**
   - In `tests/unit.test.ts`, add a `modulo` test (e.g., `calculate(10, "%", 4)` yields `2`).
   - Consider adding a second test for negative or non-integer behavior if desired, but keep consistent with existing test style (single simple case is fine).

5) **Add CLI coverage**
   - In `tests/e2e.test.ts`, add a new `calc` invocation using `%` (e.g., `calc 10 % 4` expecting stdout `2`).
   - Ensure the test asserts no stderr and exit code `0`, matching existing pattern.

6) **Documentation touch-up (optional but helpful)**
   - If you want the CLI usage to list supported operators, add a short note in `README.md` (or leave as-is since CLI help is authoritative).

**Validation**
- Run unit and e2e tests with Bun:
  - `bun test`
- Optionally run CLI manually:
  - `bun run src/index.ts calc 10 % 4`

**No External Dependencies**
- No new libraries or APIs are required for modulo support.