### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,9 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
+    default:
+      throw new Error(`Unsupported operator: ${operator}`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
**Summary**
- Added `%` to the operator type, CLI validation, and calculator switch with an explicit unsupported-operator error.
- Added modulo coverage in unit and CLI e2e tests.

**Tests**
- Not run (per instructions).

## Plan
Add modulo operator support by extending the operator type, CLI validation, calculator logic, and tests; no new dependencies needed.

- **Scope confirmation**: Target files are `src/cli.ts`, `src/index.ts`, `tests/unit.test.ts`, `tests/e2e.test.ts`; these define the operator type, CLI arg validation, calculation logic, and coverage.
- **Operator surface**: Update the operator union and CLI choices to include `%`, ensuring TypeScript and yargs accept the new operator.
- **Calculation logic**: Implement modulo behavior in the switch; decide and document expected output for negative operands and zero divisor based on JS `%` semantics.
- **Tests**: Add unit test(s) for `%` and an e2e CLI test for `calc` with `%` to validate parsing/output; include a zero-divisor case if you want to lock in JS behavior.
- **Docs (optional)**: If you want users to discover it, update `README.md` with the new operator example.

## Detailed plan

1. **Update operator type and CLI parsing**
   - Edit `src/cli.ts` to extend `Operator` to `"+" | "-" | "*" | "/" | "%"`.
   - Add a `%` case in the `calculate` switch. If you want stronger type safety, add a default `throw` for unreachable operators.
   - Edit `src/index.ts` to allow `%` in the yargs `choices` array and in the operator cast type.
   - Rationale: yargs validates operator input; the TS union must match to avoid runtime-only acceptance.

2. **Implement modulo calculation behavior**
   - In `calculate`, add:
     - `case "%": return left % right;`
   - Decide how to handle divide-by-zero: keep JS semantics (`NaN`), or explicitly guard/throw. If you choose to guard, align tests and CLI expectations accordingly.
   - Note: JS `%` uses remainder, not mathematical modulo (negative values keep the sign of the left operand). If this matters, document or normalize.

3. **Expand unit tests**
   - In `tests/unit.test.ts`, add a test for `%` (e.g., `calculate(10, "%", 3) === 1`).
   - Optionally add negative or zero-divisor coverage to lock in behavior.
   - Ensure test names are parallel with existing arithmetic tests.

4. **Expand CLI e2e tests**
   - In `tests/e2e.test.ts`, add a `calc` invocation using `%` and validate stdout (e.g., `calc 10 % 3` -> `1`).
   - If you add a zero-divisor behavior, include an e2e test that asserts stdout (`NaN`) or non-zero exit if you decide to error.

5. **(Optional) README update**
   - If desired, add a brief example in `README.md` showcasing `%`.

## Assumptions & decisions to confirm
- `%` should use standard JavaScript remainder behavior; no special handling for negatives or zero divisor unless explicitly required.
- CLI should remain strict with allowed operators (handled via `choices`).

## Validation
- Run `bun test` to cover unit/e2e.
- Run `bun run src/index.ts calc 10 % 3` to manually verify output if desired.