### PR TITLE
feat: add modulo operator support to calculator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc modulo prints the remainder", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary: Support Modulo Operator

## Overview
Added modulo operator (`%`) support to the arithmetic calculator CLI, allowing users to calculate the remainder of division between two numbers.

## Files Modified

### 1. `src/cli.ts`
- Updated `Operator` type to include `"%"` in the union type
- Added `case "%": return left % right;` to the switch statement in `calculate()` function

### 2. `src/index.ts`
- Added `"%"` to the `choices` array in the operator positional argument
- Updated the type cast for the operator variable to include `"%"`

### 3. `tests/unit.test.ts`
- Added unit test for modulo operation: `expect(calculate(10, "%", 3)).toBe(1)`

### 4. `tests/e2e.test.ts`
- Added end-to-end test for modulo CLI command: `calc 10 % 3` → `1`

## Commit Details
- **Commit:** `79273c5`
- **Branch:** `o-agents/issue-4-20260114-194516_0414-2`
- **Message:** `feat: add modulo operator support to calculator`

## Changes Summary
- 4 files changed
- 16 insertions
- 3 deletions

## Plan
# Implementation Plan: Support Modulo Operator

## Overview

Add modulo operator (`%`) support to the existing arithmetic calculator CLI. This feature will allow users to calculate the remainder of division between two numbers using the same pattern as the existing four arithmetic operations.

## Current Implementation Summary

The calculator currently supports four arithmetic operations (`+`, `-`, `*`, `/`) implemented across two files:
- **`src/cli.ts`**: Contains the `Operator` type definition and `calculate()` function
- **`src/index.ts`**: Contains the yargs CLI configuration with operator validation

## Files to Modify

### 1. `src/cli.ts`

**Location:** Lines 3-14

**Current Code:**
```typescript
export type Operator = "+" | "-" | "*" | "/";

export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
  }
}
```

**Changes Required:**

1. **Update the `Operator` type** (line 3):
   - Add `"%"` to the union type
   - New type: `export type Operator = "+" | "-" | "*" | "/" | "%";`

2. **Add modulo case to switch statement** (after line 13):
   - Add new case block:
     ```typescript
     case "%":
       return left % right;
     ```

**Modified Code:**
```typescript
export type Operator = "+" | "-" | "*" | "/" | "%";

export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
    case "%":
      return left % right;
  }
}
```

---

### 2. `src/index.ts`

**Location:** Lines 20-24

**Current Code:**
```typescript
.positional("operator", {
  type: "string",
  choices: ["+", "-", "*", "/"] as const,
  demandOption: true,
})
```

**Changes Required:**

1. **Update the `choices` array** (line 22):
   - Add `"%"` to the allowed operators
   - New array: `choices: ["+", "-", "*", "/", "%"] as const`

2. **Update the type cast** (line 29):
   - Current: `const operator = argv.operator as "+" | "-" | "*" | "/";`
   - New: `const operator = argv.operator as "+" | "-" | "*" | "/" | "%";`
   - Alternatively, import and use the `Operator` type: `const operator = argv.operator as Operator;`

**Modified Code (relevant sections):**
```typescript
.positional("operator", {
  type: "string",
  choices: ["+", "-", "*", "/", "%"] as const,
  demandOption: true,
})
```

And:
```typescript
const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
```

---

### 3. `tests/unit.test.ts`

**Location:** After line 19

**Current Code:**
```typescript
describe("calculate", () => {
  test("adds", () => {
    expect(calculate(2, "+", 3)).toBe(5);
  });

  test("subtracts", () => {
    expect(calculate(10, "-", 4)).toBe(6);
  });

  test("multiplies", () => {
    expect(calculate(3, "*", 4)).toBe(12);
  });

  test("divides", () => {
    expect(calculate(12, "/", 3)).toBe(4);
  });
});
```

**Changes Required:**

Add a new test case for the modulo operation after the existing tests:

```typescript
test("modulos", () => {
  expect(calculate(10, "%", 3)).toBe(1);
});
```

---

### 4. `tests/e2e.test.ts`

**Location:** After line 37

**Changes Required:**

Add a new end-to-end test case for the modulo CLI command:

```typescript
test("calc modulo prints the remainder", async () => {
  const result = await runCli(["calc", "10", "%", "3"]);
  expect(result.exitCode).toBe(0);
  expect(result.stderr).toBe("");
  expect(result.stdout).toBe("1");
});
```

---

## Implementation Steps

1. **Modify `src/cli.ts`:**
   - Add `"%"` to the `Operator` type union
   - Add `case "%": return left % right;` to the switch statement

2. **Modify `src/index.ts`:**
   - Add `"%"` to the `choices` array in the operator positional argument
   - Update the type cast for the operator variable

3. **Modify `tests/unit.test.ts`:**
   - Add unit test for modulo operation

4. **Modify `tests/e2e.test.ts`:**
   - Add end-to-end test for modulo CLI command

5. **Run tests to verify:**
   ```bash
   bun test
   ```

6. **Manual verification:**
   ```bash
   bun run src/index.ts calc 10 % 3
   # Expected output: 1
   ```

---

## Technical Notes

- **JavaScript Modulo Behavior:** The `%` operator in JavaScript returns the remainder of division. For negative numbers, the result takes the sign of the dividend (e.g., `-7 % 3 = -1`).
- **No External Dependencies:** This feature uses JavaScript's native `%` operator; no additional libraries are required.
- **Type Safety:** The TypeScript `Operator` type ensures compile-time validation of valid operators.

---

## Testing Verification

After implementation, all existing tests should continue to pass, and the new modulo tests should pass:

| Test | Input | Expected Output |
|------|-------|-----------------|
| Unit test | `calculate(10, "%", 3)` | `1` |
| E2E test | `calc 10 % 3` | `1` |

Additional manual test cases to consider:
- `calc 7 % 2` → `1`
- `calc 8 % 4` → `0`
- `calc 5 % 7` → `5`