### PR TITLE
feat: add modulo operator to calculator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Implemented modulo operator support across the CLI and calculator, and added matching unit/e2e coverage.

Details
- Added `%` to the operator type and calculator switch in `src/cli.ts`.
- Allowed `%` in CLI validation and handler typing in `src/index.ts`.
- Added modulo assertions in `tests/unit.test.ts` and `tests/e2e.test.ts`.

Tests not run (per instructions).

Next steps
1. Run `bun test` if you want to validate locally.

## Plan
Support modulo operator in CLI calculator by extending the operator type, CLI argument validation, and tests to include `%` with JavaScript remainder semantics.

**Plan**
- Review existing operator handling and CLI validation to confirm all operator-related touchpoints: `src/cli.ts`, `src/index.ts`, `tests/unit.test.ts`, `tests/e2e.test.ts`.
- Update core calculation logic in `src/cli.ts` by adding `%` to `Operator` and handling it in the `calculate` switch to return `left % right`.
- Update CLI argument constraints in `src/index.ts` by adding `%` to the `choices` array and widening the `operator` type union used in the command handler.
- Expand unit coverage in `tests/unit.test.ts` with a modulo case (e.g., `calculate(10, "%", 4)` returns `2`) and consider an additional case that documents JS remainder behavior with negatives if desired.
- Expand end-to-end coverage in `tests/e2e.test.ts` with a `calc` invocation using `%` (e.g., `calc 10 % 4`) to validate CLI parsing and output formatting.
- Run test suite (e.g., `bun test`) to verify new behavior and ensure no regressions.

**Assumptions**
- Modulo uses JavaScript remainder semantics (`%`) without custom handling for negatives or zero; no validation changes are required beyond allowing `%` as an operator.
- No external libraries are needed.