### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Implemented modulo operator support across CLI parsing, core calculation, and tests to cover `%` end-to-end in `src/cli.ts`, `src/index.ts`, `tests/unit.test.ts`, and `tests/e2e.test.ts`.

Details:
- Extended `Operator` and `calculate` to handle `%` and return `left % right`.
- Added `%` to CLI choices and operator typing for yargs.
- Added unit and e2e coverage for modulo (`10 % 4 -> 2`).

Tests not run (per instruction).

## Plan
**Implementation Plan**
- Review current operator handling to confirm scope and touchpoints: CLI parsing in `src/index.ts`, core logic and operator type in `src/cli.ts`, unit tests in `tests/unit.test.ts`, and CLI coverage in `tests/e2e.test.ts`.
- Update the operator type to include modulo: extend `Operator` in `src/cli.ts` to add `%` and add a `case "%"` in `calculate` returning `left % right` so runtime behavior matches the new operator.
- Extend CLI validation: add `%` to the `choices` list in `src/index.ts` and widen the local `operator` type annotation so yargs accepts modulo and type inference stays accurate.
- Add unit coverage for modulo: in `tests/unit.test.ts`, add a test like `calculate(10, "%", 4)` expecting `2`, and consider a negative/zero edge case if desired (align with existing minimal test style).
- Add CLI coverage for modulo: in `tests/e2e.test.ts`, add a `calc` invocation like `calc 10 % 4` expecting `2` to ensure end-to-end parsing and output formatting work.
- Run tests after implementation: `bun test` to validate both unit and e2e paths for the new operator.