### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,9 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
+
+  throw new Error(`Unsupported operator: ${operator}`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo support end-to-end by extending the operator type/switch and CLI choices, plus new unit and e2e coverage for `%` (`src/cli.ts`, `src/index.ts`, `tests/unit.test.ts`, `tests/e2e.test.ts`).

Tests not run (per instructions).

## Plan
Implement modulo operator support across CLI parsing, core calculation, and tests.

Plan
- Review current arithmetic flow: `src/index.ts` CLI defines accepted operators and calls `calculate` in `src/cli.ts`, which currently supports `+ - * /` only; unit tests in `tests/unit.test.ts` and CLI coverage in `tests/e2e.test.ts` assert those operations only.
- Update operator typing and logic:
  - Extend `Operator` union in `src/cli.ts` to include `%`.
  - Add a `%` case to `calculate` with `left % right` and ensure the switch remains exhaustive; decide whether to add a default that throws for safety.
- Extend CLI argument validation:
  - In `src/index.ts`, add `%` to the `choices` array for the `operator` positional.
  - Update the operator type assertion to include `%`.
- Expand tests:
  - Add a unit test in `tests/unit.test.ts` to cover modulo (e.g., `calculate(10, "%", 3)` => `1`).
  - Add an e2e CLI test in `tests/e2e.test.ts` to verify `calc 10 % 3` prints `1` and exits cleanly.
- Confirm documentation if needed:
  - If README lists supported operators, update it to mention `%` (currently it does not, so no change required unless you want explicit docs).
- Verification steps:
  - Run `bun test` to confirm new unit and e2e tests pass.
  - Optionally run `bun run src/index.ts calc 10 % 3` to manually verify CLI behavior.