### PR TITLE
feat: add modulo operator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ To run:
 bun run src/index.ts
 ```
 
+Supported operators for `calc` are `+`, `-`, `*`, `/`, `%`.
+
 This project was created using `bun init` in bun v1.3.5. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,9 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
+    default:
+      throw new Error(`Unsupported operator: ${operator}`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,9 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo operator support across the CLI and core calculator logic, including tests and documentation updates.

- Updated `src/cli.ts` to accept `%`, implement remainder logic, and guard against unsupported operators.
- Expanded CLI validation and typing for `%` in `src/index.ts`.
- Added modulo coverage in unit and e2e tests via `tests/unit.test.ts` and `tests/e2e.test.ts`.
- Documented supported operators in `README.md`.

Tests not run (per instructions).

## Plan
**Implementation Plan: Modulo Operator Support**

- Goal: extend the calculator CLI and core logic to support `%` alongside `+`, `-`, `*`, `/`.

**Repository Context**
- Core logic: `src/cli.ts` defines `Operator` and `calculate()`.
- CLI parsing: `src/index.ts` restricts operators in yargs choices.
- Tests: `tests/unit.test.ts` covers arithmetic; `tests/e2e.test.ts` validates CLI output.
- Docs: `README.md` describes running but not operators.

**Plan**
1. Update operator types and calculation logic
   - Edit `src/cli.ts`:
     - Extend `Operator` union to include `%`.
     - Add a `%` case in `calculate()` that returns `left % right`.
     - Ensure the switch still returns a number for all operator branches.
   - Assumption: use JavaScript `%` semantics (remainder, not mathematical modulus), matching the rest of the numeric operations.

2. Expand CLI argument validation
   - Edit `src/index.ts`:
     - Add `%` to the yargs `choices` array for the `operator` positional.
     - Update the `operator` type annotation in the handler to include `%`.

3. Add tests for modulo
   - Edit `tests/unit.test.ts`:
     - Add a new test case for `calculate(10, "%", 3)` expecting `1`.
     - Consider adding an additional case for non-even division (e.g., `calculate(10, "%", 4)` expecting `2`) if desired for clarity.
   - Edit `tests/e2e.test.ts`:
     - Add a CLI test to run `calc 10 % 3` and assert stdout is `1` with no stderr.

4. (Optional) Document supported operators
   - Edit `README.md`:
     - Add a short snippet or line stating supported operators now include `%`.

**Validation Plan**
- Run unit and e2e tests:
  - `bun test`
- Manually verify CLI parsing:
  - `bun run src/index.ts calc 10 % 3` → should print `1`.

**No External Dependencies**
- No new libraries or external APIs are required for modulo support.