### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
## Summary
- Added `%` to calculator operator handling and CLI validation in `src/cli.ts` and `src/index.ts`.
- Expanded unit and e2e coverage for modulo in `tests/unit.test.ts` and `tests/e2e.test.ts`.

## Tests
- Not run (per instructions).

## Plan
Implement modulo operator support in CLI calculator

Context summary (current behavior)
- Operator type and calculate logic live in `src/cli.ts` and only handle `+ - * /`.
- CLI command parser in `src/index.ts` restricts operators to `+ - * /`.
- Unit tests in `tests/unit.test.ts` cover four operations; e2e in `tests/e2e.test.ts` covers hello and one calc case.

Assumptions
- Modulo is the JavaScript `%` operator on numbers, consistent with other operations.
- No new dependencies are required.

Plan
1) Update core calculation logic
- Edit `src/cli.ts`:
  - Extend `Operator` union to include `%`.
  - Add a `case "%"` to `calculate` that returns `left % right`.
  - Ensure switch remains exhaustive (TypeScript will infer return type).

2) Update CLI argument validation
- Edit `src/index.ts`:
  - Add `%` to the `choices` array for the `operator` positional.
  - Update the `operator` type assertion to include `%`.

3) Expand tests
- Edit `tests/unit.test.ts`:
  - Add a test for modulo (e.g., `calculate(10, "%", 3)` equals `1`).
- Edit `tests/e2e.test.ts`:
  - Add a CLI test using `calc` with `%` (e.g., `calc 10 % 3` returns `1`).

4) (Optional) Documentation alignment
- If the README or other docs describe supported operators, update them to include `%`.

Verification steps
- Run unit tests: `bun test tests/unit.test.ts`.
- Run e2e tests: `bun test tests/e2e.test.ts`.
- Alternatively, run full test suite: `bun test`.