### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,11 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
+    default: {
+      const _exhaustiveCheck: never = operator;
+      throw new Error(`Unknown operator: ${_exhaustiveCheck}`);
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added `%` support to the calculator core and CLI operator parsing, including an exhaustiveness guard in `calculate`.

- Updated `src/cli.ts` to include `%` in `Operator` and handle modulo.
- Expanded CLI operator choices and typing in `src/index.ts` to accept `%`.
- Added unit and CLI e2e tests covering modulo behavior in `tests/unit.test.ts` and `tests/e2e.test.ts`.

Tests not run (per instructions).

## Plan
**Goal**
Add modulo (%) support to the calculator functionality (library + CLI), plus tests, without changing unrelated behavior.

**Current State (Relevant Files)**
- `src/cli.ts` defines `Operator` and `calculate`, currently handling `+ - * /`.
- `src/index.ts` wires CLI with yargs and restricts operator choices to `+ - * /`.
- `tests/unit.test.ts` validates calculate for the four existing operators.
- `tests/e2e.test.ts` validates CLI output for `calc` with `+`.

**Assumptions**
- Modulo should follow JavaScript’s `%` operator semantics (remainder, not mathematical modulo) since the codebase is TypeScript and uses JS arithmetic.
- No new dependencies are required; use existing Bun + yargs setup.

**Plan**
1. Update core operator type and implementation
   - Edit `src/cli.ts` to extend `Operator` to include `%`.
   - Add a `%` case to `calculate` using `left % right`.
   - Ensure the function remains total (either keep TypeScript exhaustiveness or add a `default` that throws if needed).

2. Extend CLI operator parsing and types
   - Edit `src/index.ts` to add `%` to the yargs `choices` array for the `operator` positional.
   - Update the local `operator` type cast to include `%` so TS stays aligned with the new Operator union.

3. Add unit coverage for modulo
   - Edit `tests/unit.test.ts` to add a test for modulo, e.g. `calculate(10, "%", 3) === 1`.
   - Optionally add a negative or zero case if desired (e.g. `-10 % 3 === -1` or `10 % 0` behavior), but keep consistent with existing simple tests.

4. Add CLI end-to-end coverage
   - Edit `tests/e2e.test.ts` to add a `calc` invocation with `%` and assert the stdout matches the remainder.

5. Validate (for implementers)
   - Run `bun test` to ensure both unit and e2e tests pass.
   - Optionally run a single CLI example: `bun run src/index.ts calc 10 % 3` and confirm output `1`.

**Notes / Edge Cases to Confirm**
- Division by zero or modulo by zero is not currently handled; leave as-is unless requirements change.
- `%` in shells can be a special character on some platforms; in tests and CLI usage it’s passed as a literal argument, so quoting may be necessary in docs or examples if added.