### PR TITLE
feat: add modulo operator support to calculator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc modulo prints only the number result", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary: Support Modulo Operator

## Overview
Added support for the modulo operator (`%`) to the calculator CLI. The modulo operator returns the remainder of a division operation (e.g., `10 % 3` returns `1`).

## Files Modified

### 1. `src/cli.ts`
- **Line 3**: Added `"%"` to the `Operator` type union
- **Lines 15-16**: Added `case "%"` to the `calculate` function's switch statement

### 2. `src/index.ts`
- **Line 25**: Added `"%"` to the CLI choices array for the operator positional argument
- **Line 35**: Updated the operator type cast to include `"%"`

### 3. `tests/unit.test.ts`
- **Lines 21-23**: Added unit test for modulo operation (`10 % 3 = 1`)

### 4. `tests/e2e.test.ts`
- **Lines 41-46**: Added E2E test for modulo operation via CLI

## Commit Details
- **Branch**: `o-agents/issue-4-20260115-214855_0438-2`
- **Commit**: `6ba13e5` - feat: add modulo operator support to calculator
- **Pushed to**: origin remote

## Plan
# Implementation Plan: Support Modulo Operator

## Overview

This plan adds support for the modulo operator (`%`) to the existing calculator functionality. The modulo operator returns the remainder of a division operation (e.g., `10 % 3` returns `1`).

## Files to Modify

1. `src/cli.ts` - Core calculation logic
2. `src/index.ts` - CLI command handler
3. `tests/unit.test.ts` - Unit tests
4. `tests/e2e.test.ts` - End-to-end tests

---

## Step 1: Update the Operator Type Definition

**File:** `src/cli.ts`
**Line:** 3

### Current Code
```typescript
export type Operator = "+" | "-" | "*" | "/";
```

### Modified Code
```typescript
export type Operator = "+" | "-" | "*" | "/" | "%";
```

### Explanation
Add `"%"` to the union type to include the modulo operator as a valid operator option.

---

## Step 2: Add Modulo Case to Calculate Function

**File:** `src/cli.ts`
**Lines:** 5-16

### Current Code
```typescript
export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
  }
}
```

### Modified Code
```typescript
export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
    case "%":
      return left % right;
  }
}
```

### Explanation
Add a new case for the `%` operator that uses JavaScript's native modulo operator to compute the remainder.

---

## Step 3: Update CLI Operator Choices

**File:** `src/index.ts`
**Lines:** 23-26

### Current Code
```typescript
.positional("operator", {
  type: "string",
  choices: ["+", "-", "*", "/"] as const,
  demandOption: true,
})
```

### Modified Code
```typescript
.positional("operator", {
  type: "string",
  choices: ["+", "-", "*", "/", "%"] as const,
  demandOption: true,
})
```

### Explanation
Add `"%"` to the choices array so the CLI accepts the modulo operator as a valid input.

---

## Step 4: Update Operator Type Cast

**File:** `src/index.ts`
**Line:** 35

### Current Code
```typescript
const operator = argv.operator as "+" | "-" | "*" | "/";
```

### Modified Code
```typescript
const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
```

### Explanation
Update the type cast to include `"%"` for type consistency.

---

## Step 5: Add Unit Test for Modulo Operation

**File:** `tests/unit.test.ts`
**Location:** Inside the `describe("calculate", ...)` block, after the division test (line 19)

### Code to Add
```typescript
test("modulo", () => {
  expect(calculate(10, "%", 3)).toBe(1);
});
```

### Explanation
Add a unit test that verifies the modulo operation works correctly. `10 % 3` equals `1` because 10 divided by 3 is 3 with a remainder of 1.

---

## Step 6: Add E2E Test for Modulo Operation

**File:** `tests/e2e.test.ts`
**Location:** Inside the `describe("cli", ...)` block, after the calc test (line 39)

### Code to Add
```typescript
test("calc modulo prints only the number result", async () => {
  const result = await runCli(["calc", "10", "%", "3"]);
  expect(result.exitCode).toBe(0);
  expect(result.stderr).toBe("");
  expect(result.stdout).toBe("1");
});
```

### Explanation
Add an E2E test that verifies the CLI correctly handles the modulo operator and outputs the expected result.

---

## Summary of Changes

| File | Change Description |
|------|-------------------|
| `src/cli.ts:3` | Add `"%"` to `Operator` type |
| `src/cli.ts:14-15` | Add `case "%"` to `calculate` function |
| `src/index.ts:25` | Add `"%"` to CLI choices array |
| `src/index.ts:35` | Add `"%"` to operator type cast |
| `tests/unit.test.ts:20-22` | Add unit test for modulo operation |
| `tests/e2e.test.ts:41-47` | Add E2E test for modulo via CLI |

---

## Testing

After implementing these changes, run the test suite to verify:

```bash
bun test --timeout 1800000
```

Expected behavior:
- All existing tests should pass
- New modulo tests should pass
- CLI should accept `%` as a valid operator

---

## Edge Cases to Consider

The implementation uses JavaScript's native `%` operator, which handles:
- Positive modulo: `10 % 3` = `1`
- Zero as right operand: `10 % 0` = `NaN` (JavaScript behavior)
- Negative numbers: `-10 % 3` = `-1` (JavaScript behavior preserves sign of dividend)
- Floating point: `10.5 % 3` = `1.5`

No additional edge case handling is required for this feature as it follows the same pattern as existing operators (e.g., division by zero for `/` also returns `Infinity` or `NaN`).