### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo operator support across the CLI and calculation logic, plus tests to cover the new behavior.

- Extended operator union and calculate switch to handle `%` in `src/cli.ts`.
- Allowed `%` in CLI parsing and operator typing in `src/index.ts`.
- Added unit and E2E tests for modulo in `tests/unit.test.ts` and `tests/e2e.test.ts`.

Tests not run (per instructions).

Next steps (optional):
1) Run `bun test`.
2) Spot-check with `bun run src/index.ts calc 10 % 3`.

## Plan
**Implementation Plan**
- Review operator handling and CLI parsing to confirm current arithmetic support and where to extend it: `src/cli.ts`, `src/index.ts`, `tests/unit.test.ts`, `tests/e2e.test.ts`.
- Extend the operator type and calculation logic to include modulo:
  - Update `Operator` union in `src/cli.ts` to include `%`.
  - Add a `%` case to `calculate` using JavaScript’s remainder operator (`left % right`). Note that this follows JS remainder semantics for negatives.
- Update CLI argument validation to allow modulo:
  - In `src/index.ts`, extend `choices` for the `operator` positional to include `%`.
  - Update the operator type assertion in the handler to include `%`.
- Add tests for modulo behavior:
  - Unit test in `tests/unit.test.ts` validating a straightforward remainder (e.g., `calculate(10, "%", 3) === 1`).
  - E2E test in `tests/e2e.test.ts` that runs `calc` with `%` and asserts stdout (e.g., `10 % 3` -> `1`).
  - If desired, add an edge case (optional) for `0` or negative inputs to document expected JS remainder behavior.
- Ensure no docs need updating (README currently generic). If you want CLI usage documented, add a brief operator list including `%` in `README.md`.
- Verify by running:
  - `bun test` to cover unit/e2e.
  - `bun run src/index.ts calc 10 % 3` as a manual spot check.

**Notes/Assumptions**
- Modulo uses JavaScript’s `%` remainder semantics (not mathematical modulo). If you need true modulo for negatives, adjust calculation accordingly and add tests to pin behavior.