### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added `%` to the shared operator type and calculator switch so modulo behaves like other operators, keeping the CLI aligned with the single `Operator` source of truth in `src/cli.ts`. Updated `src/index.ts` to accept `%` in the yargs choices and to type the operator as `Operator`, then extended coverage in `tests/unit.test.ts` and `tests/e2e.test.ts` to exercise `10 % 3` through both calculate and CLI paths.

Tests not run (per instructions).

Change summary:
- Add modulo support to the calculator operator type and switch in `src/cli.ts`.
- Extend CLI operator validation and typing for `%` in `src/index.ts`.
- Add unit and e2e tests for modulo behavior in `tests/unit.test.ts` and `tests/e2e.test.ts`.

Next steps:
1) Run `bun test` to validate unit and e2e coverage.

## Plan
**Plan**
- Review current operator typing and calculation logic in `src/cli.ts` to confirm the shared `Operator` type and switch-based implementation that needs the modulo case.
- Update the operator type to include `%` and extend `calculate` with modulo handling; confirm the switch remains exhaustive and returns a number for all operators.
- Extend CLI argument validation in `src/index.ts` to allow `%` in the `choices` list, and keep the CLI operator type aligned with the shared `Operator` definition from `src/cli.ts` for consistent typing.
- Update unit coverage in `tests/unit.test.ts` to include a modulo case (e.g., `10 % 3`), ensuring parity with other arithmetic tests.
- Update e2e coverage in `tests/e2e.test.ts` to exercise `calc` with `%` so the CLI path validates operator choices and output formatting.
- If documentation enumerates supported operators (check `README.md`), update it to mention `%` alongside the other four operations.

**Notes/Assumptions**
- Use the shared `Operator` type in `src/cli.ts` as the single source of truth to match the comment guidance about cleaner typing.
- Expect modulo to behave as JavaScript `%` (remainder) and accept non-integers if provided, consistent with the existing calculator behavior.

**Verification**
- Run `bun test` to confirm unit and e2e tests pass after updates.