### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo operator support end-to-end by extending the shared `Operator` type, wiring `%` into CLI validation, and handling `%` in `calculate`.

- Updated arithmetic logic to include `%` in `src/cli.ts`.
- Aligned CLI operator choices and typing to the shared `Operator` in `src/index.ts`.
- Added a modulo unit test in `tests/unit.test.ts`.

Tests not run (per requirement).

## Plan
**Implementation Plan**
- Review existing operator handling in `src/cli.ts`, CLI argument validation in `src/index.ts`, and coverage in `tests/unit.test.ts` to confirm the current four-operator flow and where to extend it.
- Extend the `Operator` union in `src/cli.ts` to include `%` and add a modulo branch in `calculate` that returns `left % right`.
- Update the CLI argument config in `src/index.ts` to accept `%` in the operator choices and use the shared `Operator` type (import it as a type-only import) instead of the inline union so runtime imports remain unchanged.
- Add a new unit test in `tests/unit.test.ts` to validate modulo behavior (e.g., `calculate(10, "%", 3)` equals `1`), and confirm existing tests still cover the other four operators.
- Consider a small README update only if CLI usage examples are present or needed; otherwise no documentation change is required.

**Notes/Assumptions**
- No external libraries or APIs are needed; modulo is a native JavaScript operator.
- The CLI should mirror the `Operator` type to avoid drift between type and runtime validation.

**Verification**
- Run `bun test` (or `bun test tests/unit.test.ts`) to confirm the new modulo test passes alongside existing arithmetic tests.