### PR TITLE
feat: add modulo operator support to calculator CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc modulo prints only the number result", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary: Support Modulo Operator

## Overview

Added support for the modulo operator (`%`) to the calculator CLI, extending the existing operators (`+`, `-`, `*`, `/`).

## Files Modified

### 1. `src/cli.ts`
- Updated `Operator` type to include `"%"` in the union type
- Added `case "%": return left % right;` to the `calculate` function switch statement

### 2. `src/index.ts`
- Added `type Operator` import from `./cli`
- Added `"%"` to the operator choices array
- Changed type assertion to use the imported `Operator` type instead of inline union

### 3. `tests/unit.test.ts`
- Added unit test for modulo operation: `expect(calculate(10, "%", 3)).toBe(1)`

### 4. `tests/e2e.test.ts`
- Added E2E test for modulo via CLI: verifies `calc 10 % 3` outputs `1`

## Commit Details

- **Commit hash:** 43622d9
- **Commit message:** `feat: add modulo operator support to calculator CLI`
- **Branch:** `o-agents/issue-4-20260116-155934_0590-2`
- **Pushed to:** origin

## Plan
# Implementation Plan: Support Modulo Operator

## Overview

Add support for the modulo operator (`%`) to the existing calculator CLI, which currently supports addition (`+`), subtraction (`-`), multiplication (`*`), and division (`/`).

## Files to Modify

### 1. `src/cli.ts`

**Purpose:** Add modulo operator to the type definition and implement the calculation logic.

**Changes:**

#### 1.1 Update the `Operator` type (line 3)

**Current:**
```typescript
export type Operator = "+" | "-" | "*" | "/";
```

**Updated:**
```typescript
export type Operator = "+" | "-" | "*" | "/" | "%";
```

#### 1.2 Add modulo case to the `calculate` function switch statement (after line 14)

**Add the following case before the closing brace of the switch statement:**
```typescript
    case "%":
      return left % right;
```

**Complete updated `calculate` function:**
```typescript
export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
    case "%":
      return left % right;
  }
}
```

---

### 2. `src/index.ts`

**Purpose:** Update the CLI argument parser to accept the modulo operator.

**Changes:**

#### 2.1 Update the operator choices array (line 25)

**Current:**
```typescript
choices: ["+", "-", "*", "/"] as const,
```

**Updated:**
```typescript
choices: ["+", "-", "*", "/", "%"] as const,
```

#### 2.2 Update the operator type assertion (line 35)

**Current:**
```typescript
const operator = argv.operator as "+" | "-" | "*" | "/";
```

**Updated (use type-only import to avoid runtime overhead):**
```typescript
const operator = argv.operator as Operator;
```

**Note:** This requires importing the `Operator` type. Update line 3:

**Current:**
```typescript
import { calculate, currentText } from "./cli";
```

**Updated:**
```typescript
import { calculate, currentText, type Operator } from "./cli";
```

Using `type Operator` ensures it's a type-only import, avoiding unnecessary runtime imports.

---

### 3. `tests/unit.test.ts`

**Purpose:** Add unit test for the modulo operation.

**Changes:**

#### 3.1 Add a new test case for modulo (after line 19, before the closing `});`)

```typescript
  test("modulo", () => {
    expect(calculate(10, "%", 3)).toBe(1);
  });
```

**Complete updated test file:**
```typescript
import { describe, expect, test } from "bun:test";
import { calculate } from "../src/cli";

describe("calculate", () => {
  test("adds", () => {
    expect(calculate(2, "+", 3)).toBe(5);
  });

  test("subtracts", () => {
    expect(calculate(10, "-", 4)).toBe(6);
  });

  test("multiplies", () => {
    expect(calculate(3, "*", 4)).toBe(12);
  });

  test("divides", () => {
    expect(calculate(12, "/", 3)).toBe(4);
  });

  test("modulo", () => {
    expect(calculate(10, "%", 3)).toBe(1);
  });
});
```

---

### 4. `tests/e2e.test.ts`

**Purpose:** Add end-to-end test for the modulo operation via CLI.

**Changes:**

#### 4.1 Add a new E2E test case for modulo (after line 39, before the closing `});`)

```typescript
  test("calc modulo prints only the number result", async () => {
    const result = await runCli(["calc", "10", "%", "3"]);
    expect(result.exitCode).toBe(0);
    expect(result.stderr).toBe("");
    expect(result.stdout).toBe("1");
  });
```

---

## Summary of Changes

| File | Line(s) | Change Description |
|------|---------|-------------------|
| `src/cli.ts` | 3 | Add `"%"` to `Operator` type union |
| `src/cli.ts` | 14-15 | Add `case "%": return left % right;` to switch |
| `src/index.ts` | 3 | Import `type Operator` from `./cli` |
| `src/index.ts` | 25 | Add `"%"` to choices array |
| `src/index.ts` | 35 | Change type assertion to use `Operator` type |
| `tests/unit.test.ts` | 20-22 | Add unit test for modulo operation |
| `tests/e2e.test.ts` | 40-45 | Add E2E test for modulo via CLI |

## Verification Steps

After implementing the changes, run:

1. **Type check:** `bun run tsc --noEmit`
2. **Unit tests:** `bun test tests/unit.test.ts`
3. **E2E tests:** `bun test tests/e2e.test.ts`
4. **Manual verification:** `bun run src/index.ts calc 10 % 3` (should output `1`)

## Notes

- The JavaScript `%` operator is the remainder operator, which behaves like modulo for positive numbers
- No external libraries are required; this uses native JavaScript operators
- The `type Operator` import syntax ensures the import is erased at runtime, following the winner PR's approach mentioned in the comments