### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,11 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
+    default: {
+      const exhaustiveCheck: never = operator;
+      throw new Error(`Unhandled operator: ${exhaustiveCheck}`);
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo support to the calculator core and CLI parsing, including an exhaustive operator guard in `src/cli.ts` and updated yargs operator choices in `src/index.ts`.
- Added unit coverage for modulo in `tests/unit.test.ts`.
- Added E2E coverage for `calc 10 % 3` in `tests/e2e.test.ts`.

Tests not run (per instruction).

## Plan
**Plan**
- Inspect current calculator behavior in `src/cli.ts` and CLI parsing in `src/index.ts` to confirm operator type and yargs choices are limited to +, -, *, / and that result printing is plain stdout.
- Extend core operator support:
  - Update `src/cli.ts` `Operator` union to include `%` and add a `case "%"` branch in `calculate` that returns `left % right` (JS remainder semantics).
  - Keep switch exhaustive; if TypeScript warns about missing return, add an explicit default/never guard.
- Expand CLI parsing to accept modulo:
  - Update `src/index.ts` yargs `choices` to include `%` and widen the operator type cast to `"+" | "-" | "*" | "/" | "%"`.
  - Ensure CLI usage string remains accurate if any operator list is surfaced (no change needed if it is generic).
- Add unit tests for modulo in `tests/unit.test.ts` (e.g., `calculate(10, "%", 3)` returns `1`, optionally add a negative case to document JS remainder behavior).
- Add E2E coverage in `tests/e2e.test.ts` to run `calc 10 % 3` and assert stdout is `1` with empty stderr and exit code 0.
- Run tests locally with `bun test` and confirm CLI runs with `bun run src/index.ts calc 10 % 3` (or the test harness) to validate the new operator end-to-end.