### PR TITLE
refactor: replace yargs with commander Co-authored-by: DuelingAgents-Bot (Gemini CLI) <bot@dueling-agents.com>

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "agent-benchmark",
       "dependencies": {
-        "yargs": "18.0.0",
+        "commander": "14.0.2",
       },
       "devDependencies": {
         "@types/bun": "1.3.5",
@@ -19,27 +19,15 @@
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
-    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+    "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
     "detect-indent": ["detect-indent@7.0.2", "", {}, "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A=="],
 
     "detect-newline": ["detect-newline@4.0.1", "", {}, "sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
-
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
-    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
-    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
     "git-hooks-list": ["git-hooks-list@4.1.1", "", {}, "sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA=="],
 
@@ -53,22 +41,10 @@
 
     "sort-package-json": ["sort-package-json@3.6.0", "", { "dependencies": { "detect-indent": "^7.0.2", "detect-newline": "^4.0.1", "git-hooks-list": "^4.1.1", "is-plain-obj": "^4.1.0", "semver": "^7.7.3", "sort-object-keys": "^2.0.1", "tinyglobby": "^0.2.15" }, "bin": { "sort-package-json": "cli.js" } }, "sha512-fyJsPLhWvY7u2KsKPZn1PixbXp+1m7V8NWqU8CvgFRbMEX41Ffw1kD8n0CfJiGoaSfoAvbrqRRl/DcHO8omQOQ=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
-
-    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
-
-    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
-
-    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "typescript": "5.9.3"
   },
   "dependencies": {
-    "yargs": "18.0.0"
+    "commander": "14.0.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,43 +1,29 @@
-import yargs from "yargs";
-import { hideBin } from "yargs/helpers";
+import { Command, Argument } from "commander";
 import { calculate, currentText } from "./cli";
 
-yargs(hideBin(process.argv))
-  .command(
-    "hello",
-    "Print the current text",
-    () => {},
-    () => {
-      console.log(currentText);
-    },
-  )
-  .command(
-    "calc <left> <operator> <right>",
-    "Calculate a result from two numbers and an operator",
-    (cmd) =>
-      cmd
-        .positional("left", {
-          type: "number",
-          demandOption: true,
-        })
-        .positional("operator", {
-          type: "string",
-          choices: ["+", "-", "*", "/"] as const,
-          demandOption: true,
-        })
-        .positional("right", {
-          type: "number",
-          demandOption: true,
-        }),
-    (argv) => {
-      const left = argv.left as number;
-      const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+const program = new Command();
 
-      console.log(calculate(left, operator, right));
-    },
+program
+  .command("hello")
+  .description("Print the current text")
+  .action(() => {
+    console.log(currentText);
+  });
+
+program
+  .command("calc")
+  .description("Calculate a result from two numbers and an operator")
+  .addArgument(new Argument("<left>", "Left operand").argParser(parseFloat))
+  .addArgument(
+    new Argument("<operator>", "Operator").choices(["+", "-", "*", "/"])
   )
-  .demandCommand(1)
-  .strict()
-  .help()
-  .parse();
+  .addArgument(new Argument("<right>", "Right operand").argParser(parseFloat))
+  .action((left, operator, right) => {
+    console.log(calculate(left, operator, right));
+  });
+
+program.parse();
+
+if (process.argv.length < 3) {
+  program.help();
+}


### PR DESCRIPTION
Closes #167

## Summary
Refactor the CLI implementation in `src/index.ts` to replace `yargs` with `commander`.

## Analysis of Current Implementation
- **File:** `src/index.ts` uses `yargs` to define the CLI.
- **Commands:**
    1.  `hello`: Prints a static text exported from `src/cli.ts`.
    2.  `calc <left> <operator> <right>`: Performs arithmetic operations.
        -   Arguments: `left` (number), `operator` (string, restricted to "+", "-", "*", "/"), `right` (number).
- **Configuration:** Uses `.demandCommand(1)`, `.strict()`, and `.help()`.

## Plan Steps

### 1. Dependency Management
-   **Install `commander`:**
    ```bash
    bun add commander
    ```
-   **Remove `yargs`:**
    ```bash
    bun remove yargs
    ```
    *Note: Also remove ` @types/yargs` if present in `package.json` (though not explicitly seen in the grep search, it's good practice to check).*

### 2. Refactor `src/index.ts`
-   **Imports:** Replace `yargs` imports with `import { Command, Argument } from "commander";`. Keep imports from `./cli`.
-   **Setup:** Initialize a `new Command()`.
-   **Re-implement `hello` command:**
    -   Use `.command('hello')`
    -   Set description: "Print the current text"
    -   Action: `console.log(currentText)`
-   **Re-implement `calc` command:**
    -   Use `.command('calc')`
    -   Set description: "Calculate a result from two numbers and an operator"
    -   **Arguments:**
        -   Use `.addArgument(new Argument('<left>', 'Left operand').argParser(parseFloat))` to handle the first number.
        -   Use `.addArgument(new Argument('<operator>', 'Operator').choices(["+", "-", "*", "/"]))` to restrict valid operators.
        -   Use `.addArgument(new Argument('<right>', 'Right operand').argParser(parseFloat))` to handle the second number.
    -   **Action:** Call `calculate(left, operator, right)` and print the result.
-   **General Configuration:**
    -   Add a check to enforce at least one command is used (equivalent to `demandCommand(1)`).
        -   Implementation: After `.parse()`, check `process.argv` length or listener. Alternatively, commander handles help display on error. A common pattern to strictly enforce a command invocation is checking `program.args.length` or using `.showHelpAfterError()`. However, `commander` by default does not error if no command is matched unless configured.
        -   Better approach for `demandCommand(1)` equivalence:
            ```typescript
            program.action(() => {
              program.help();
            });
            ```
            Or check `if (process.argv.length < 3) program.help();` before parsing?
            Actually, `program.showHelpAfterError()` is useful, but to enforce a command is run:
            `program.command('*').action(() => program.help())` (catch all) could work, but `commander` separates this.
            Simple check:
            ```typescript
            program.parse(process.argv);
            if (process.argv.length < 3) { // 0: bun, 1: script
               program.help();
            }
            ```
            Wait, `bun run src/index.ts` -> `bun` is arg0? No, usually arg0=bun, arg1=script. So length < 3 implies no args provided.
-   **Cleanup:** Remove all `yargs` code.

### 3. Verification
-   Run `bun run src/index.ts hello` to verify it prints the text.
-   Run `bun run src/index.ts calc 5 + 3` to verify calculation (Output: 8).
-   Run `bun run src/index.ts calc 5 % 3` to verify invalid operator error.
-   Run `bun run src/index.ts` (no args) to verify help is shown.

## External Resources
-   [Commander.js Documentation](https://github.com/tj/commander.js)

## Plan
Refactor the CLI implementation in `src/index.ts` to replace `yargs` with `commander`.

## Analysis of Current Implementation
- **File:** `src/index.ts` uses `yargs` to define the CLI.
- **Commands:**
    1.  `hello`: Prints a static text exported from `src/cli.ts`.
    2.  `calc <left> <operator> <right>`: Performs arithmetic operations.
        -   Arguments: `left` (number), `operator` (string, restricted to "+", "-", "*", "/"), `right` (number).
- **Configuration:** Uses `.demandCommand(1)`, `.strict()`, and `.help()`.

## Plan Steps

### 1. Dependency Management
-   **Install `commander`:**
    ```bash
    bun add commander
    ```
-   **Remove `yargs`:**
    ```bash
    bun remove yargs
    ```
    *Note: Also remove `@types/yargs` if present in `package.json` (though not explicitly seen in the grep search, it's good practice to check).*

### 2. Refactor `src/index.ts`
-   **Imports:** Replace `yargs` imports with `import { Command, Argument } from "commander";`. Keep imports from `./cli`.
-   **Setup:** Initialize a `new Command()`.
-   **Re-implement `hello` command:**
    -   Use `.command('hello')`
    -   Set description: "Print the current text"
    -   Action: `console.log(currentText)`
-   **Re-implement `calc` command:**
    -   Use `.command('calc')`
    -   Set description: "Calculate a result from two numbers and an operator"
    -   **Arguments:**
        -   Use `.addArgument(new Argument('<left>', 'Left operand').argParser(parseFloat))` to handle the first number.
        -   Use `.addArgument(new Argument('<operator>', 'Operator').choices(["+", "-", "*", "/"]))` to restrict valid operators.
        -   Use `.addArgument(new Argument('<right>', 'Right operand').argParser(parseFloat))` to handle the second number.
    -   **Action:** Call `calculate(left, operator, right)` and print the result.
-   **General Configuration:**
    -   Add a check to enforce at least one command is used (equivalent to `demandCommand(1)`).
        -   Implementation: After `.parse()`, check `process.argv` length or listener. Alternatively, commander handles help display on error. A common pattern to strictly enforce a command invocation is checking `program.args.length` or using `.showHelpAfterError()`. However, `commander` by default does not error if no command is matched unless configured.
        -   Better approach for `demandCommand(1)` equivalence:
            ```typescript
            program.action(() => {
              program.help();
            });
            ```
            Or check `if (process.argv.length < 3) program.help();` before parsing?
            Actually, `program.showHelpAfterError()` is useful, but to enforce a command is run:
            `program.command('*').action(() => program.help())` (catch all) could work, but `commander` separates this.
            Simple check:
            ```typescript
            program.parse(process.argv);
            if (process.argv.length < 3) { // 0: bun, 1: script
               program.help();
            }
            ```
            Wait, `bun run src/index.ts` -> `bun` is arg0? No, usually arg0=bun, arg1=script. So length < 3 implies no args provided.
-   **Cleanup:** Remove all `yargs` code.

### 3. Verification
-   Run `bun run src/index.ts hello` to verify it prints the text.
-   Run `bun run src/index.ts calc 5 + 3` to verify calculation (Output: 8).
-   Run `bun run src/index.ts calc 5 % 3` to verify invalid operator error.
-   Run `bun run src/index.ts` (no args) to verify help is shown.

## External Resources
-   [Commander.js Documentation](https://github.com/tj/commander.js)