### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,13 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
+    default:
+      return assertUnreachable(operator);
   }
+}
+
+function assertUnreachable(value: never): never {
+  throw new Error(`Unsupported operator: ${value}`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Implemented modulo support across the calculator core and CLI, plus added tests and an exhaustive operator guard.

**Change Summary**
- Added `%` to the operator union, modulo handling, and an exhaustive switch guard in `src/cli.ts`.
- Exposed `%` in CLI parsing and operator typing in `src/index.ts`.
- Added modulo coverage in unit and E2E tests in `tests/unit.test.ts` and `tests/e2e.test.ts`.

**Tests**
- Not run (per instructions).

**Next Steps**
1. Run `bun test`.

## Plan
# Implementation Plan

## Goal
Add modulo (`%`) support to the calculator CLI and core logic, including unit and E2E tests, and introduce an exhaustive switch guard for operator handling.

## Scope Review (files inspected)
- `src/cli.ts` (core operator type + calculate switch)
- `src/index.ts` (CLI command and operator choices)
- `tests/unit.test.ts` (unit coverage for operators)
- `tests/e2e.test.ts` (CLI integration tests)
- `README.md` (usage documentation)

## Plan
1. **Extend operator type and calculation logic**
   - Update `src/cli.ts`:
     - Add `%` to the `Operator` union type.
     - Add a `%` case to `calculate` that returns `left % right`.
     - Add an exhaustive switch guard in `calculate` (e.g., `default: assertUnreachable(operator)` or a `const _exhaustive: never = operator` pattern) so unsupported operators fail at compile time.
     - Ensure the function still returns a `number` in all paths.

2. **Expose modulo in CLI parsing**
   - Update `src/index.ts`:
     - Add `%` to the `choices` array for the `operator` positional argument.
     - Update the `operator` type assertion to include `%` (or import and reuse the `Operator` type from `src/cli.ts`).
     - Keep the command signature and output behavior the same, just expanded for modulo.

3. **Add unit coverage for modulo**
   - Update `tests/unit.test.ts`:
     - Add a test case that verifies `calculate(10, "%", 3)` returns `1` (or another clear modulo example).
     - Ensure existing tests remain unchanged.

4. **Add E2E coverage for modulo in the CLI**
   - Update `tests/e2e.test.ts`:
     - Add a new test invoking `calc` with `%` (e.g., `runCli(["calc", "10", "%", "3"])`).
     - Assert `stdout` equals the expected modulo result and `stderr` is empty with exit code 0.

5. **(Optional) Update docs for completeness**
   - If this repo’s usage docs should list supported operators, update `README.md` to mention `%` alongside `+ - * /`.

## Validation
- Run unit and E2E tests via Bun (consistent with existing setup), e.g. `bun test`.
- Verify CLI usage still rejects unsupported operators via yargs choices.

## Notes / Assumptions
- No external libraries or APIs are required for modulo support.
- The exhaustive switch guard is purely a TypeScript safety improvement and should not affect runtime behavior.