### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Implemented modulo operator support across core logic, CLI parsing, and tests to keep behavior consistent.
- Updated the operator union and calculation switch to handle `%` in `src/cli.ts`.
- Extended CLI operator choices and typing to accept `%` in `src/index.ts`.
- Added modulo coverage in unit and CLI tests in `tests/unit.test.ts` and `tests/e2e.test.ts`.

Tests not run (per instruction).

Next steps:
1) Run `bun test`.

## Plan
# Implementation Plan: Support Modulo Operator

## Understanding
- Arithmetic support is implemented in `src/cli.ts` (operator type + calculation switch) and wired into CLI parsing in `src/index.ts` (yargs choices + typing). Tests live in `tests/unit.test.ts` and `tests/e2e.test.ts`.

## Plan
1. Update operator type and calculation logic
   - In `src/cli.ts`, extend `Operator` to include `%`.
   - Add a `%` case in `calculate` that returns `left % right`.
   - Keep the switch exhaustive (no default) so missing operators are caught.

2. Update CLI operator validation and typing
   - In `src/index.ts`, add `%` to the `choices` array for the `operator` positional argument so the CLI accepts it.
   - Update the local `operator` typing to include `%` or reuse the exported `Operator` type from `src/cli.ts` to keep CLI and core logic in sync.

3. Add/extend tests
   - In `tests/unit.test.ts`, add a modulo test, e.g. `calculate(10, "%", 4)` returns `2`.
   - In `tests/e2e.test.ts`, add a CLI case to verify `%` parsing and output, e.g. `calc 10 % 4` prints `2`.

4. Optional documentation touch-up
   - If you document CLI usage, update `README.md` to mention `%` as a supported operator.

## Validation
- Run unit tests: `bun test`.
- Optional manual check: `bun run src/index.ts calc 10 % 4` should output `2`.

## Notes
- No external libraries or APIs are required.