### PR TITLE
fix: update hello output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
Updated the CLI greeting literal so `hello` now prints "Hello, World!", and aligned the e2e assertion to the new output.

- Updated the greeting source in `src/cli.ts` to the new text.
- Adjusted the `hello prints the current text` expectation in `tests/e2e.test.ts` to match.
- Tests not run (per instruction).

Next steps (optional):
1) Run `bun test` to verify the e2e suite.

## Specification
# Change Specification

## Goal
Print `"Hello, World!"` instead of `"Hello via Bun!"` when running the `hello` CLI command.

## Research Findings
- The CLI entry point is `src/index.ts`, which registers a `hello` command that logs `currentText` from `src/cli.ts` (`src/index.ts:1-13`).
- The current `hello` output text is stored in `currentText` in `src/cli.ts` as `"Hello via Bun!"` (`src/cli.ts:1`).
- End-to-end tests execute the CLI and assert that `hello` prints `"Hello via Bun!"` (`tests/e2e.test.ts:27-32`).
- The project is an ESM Bun CLI using `yargs` (`package.json:9-18`), but this change does not require any new libraries or APIs.

## Required Changes (by file)
- `src/cli.ts`: update the `currentText` constant so the `hello` command outputs `"Hello, World!"` instead of `"Hello via Bun!"` (`src/cli.ts:1`).
- `tests/e2e.test.ts`: update the `hello prints the current text` expectation to match `"Hello, World!"` (`tests/e2e.test.ts:27-32`).

## Constraints and Notes
- Keep the `hello` command behavior the same aside from the literal output string; it should still print the value of `currentText` with no extra formatting (`src/index.ts:6-12`).
- No external API or documentation updates are required for this change.