### PR TITLE
fix: update hello output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
Updated the hello output string to `Hello, World!` and aligned the CLI e2e assertion so the command prints the new text (`src/cli.ts`, `tests/e2e.test.ts`).

**Tests**
- Not run (per instruction).

**Next Steps**
1. Run `bun test`.
2. Open the PR from `o-agents/issue-1-20260119-163738_0692-1`.

## Specification
# Change Specification: Update hello output text

## Scope and intent
Update the CLI hello output to print `Hello, World!` instead of `Hello via Bun!`, and align the tests with the new expected output.

## Research findings
- The hello command prints a shared constant `currentText` from `src/cli.ts` when invoked via the CLI in `src/index.ts`. The command handler logs `currentText` directly. (`src/index.ts:1-12`)
- The string value for the hello output is currently defined as `Hello via Bun!` in `currentText`. (`src/cli.ts:1`)
- The end-to-end test for the `hello` command asserts `Hello via Bun!` on stdout. (`tests/e2e.test.ts:26-32`)
- No other references to `Hello via Bun!` or `Hello, World!` exist in the repository beyond the constant and test expectation. (`src/cli.ts:1`, `tests/e2e.test.ts:31`)
- The CLI uses `yargs` with Bun runtime, but no external API changes are required for a text change. (`src/index.ts:1-43`)

## Required changes by file

- `src/cli.ts:1`
  - Change the `currentText` value to the exact string `Hello, World!` so the hello command prints the requested text.

- `tests/e2e.test.ts:31`
  - Update the expected stdout string in the `hello prints the current text` test to `Hello, World!` to match the new output.

## Notes and constraints
- The hello command prints whatever `currentText` is set to; no other code paths or configuration are involved. (`src/index.ts:6-12`, `src/cli.ts:1`)
- No external library documentation is required for this change because it is a literal string update.