### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo operator support through the CLI and core calculation while keeping JavaScript remainder semantics intact, then expanded tests to cover the new operator.

- Updated `%` handling in `src/cli.ts` to extend the `Operator` type and switch logic.
- Allowed `%` in CLI parsing and operator casting in `src/index.ts` so `calc` accepts it.
- Added unit and E2E coverage for modulo in `tests/unit.test.ts` and `tests/e2e.test.ts`.

Testing not run (per instruction).

Next steps:
1. Run `bun test`.

## Specification
# Change Specification: Support Modulo Operator

## Scope and intent
Add modulo (`%`) as a supported arithmetic operator alongside the existing four operations. The CLI should accept `%` as a valid operator, the calculation logic should return the modulo result, and tests should cover the new behavior. No other functional changes are implied by the request.

## Repository findings
- The CLI command `calc <left> <operator> <right>` restricts operator choices to `+`, `-`, `*`, `/` via yargs choices, and casts `argv.operator` to a union type matching these operators. (`src/index.ts:14-37`)
- The calculation logic is centralized in `calculate`, which uses a `switch` over the `Operator` union type (`+`, `-`, `*`, `/`) and returns arithmetic results. (`src/cli.ts:3-15`)
- Unit tests validate the four operators directly via `calculate`. (`tests/unit.test.ts:1-19`)
- E2E tests exercise the CLI with `calc` and `+`. (`tests/e2e.test.ts:26-39`)
- No external arithmetic libraries are used; operator behavior is native JavaScript. (`src/cli.ts:5-15`)

## Required changes by file

### `src/cli.ts`
- Extend the `Operator` union type to include `%`, so modulo is a supported operator at the type level. (`src/cli.ts:3`)
- Add modulo handling in `calculate` so `%` returns the remainder of `left % right` and is included as a valid `switch` branch. (`src/cli.ts:5-15`)

### `src/index.ts`
- Allow `%` as an accepted CLI operator by adding it to the yargs `choices` array for the `operator` positional argument. (`src/index.ts:23-27`)
- Update the operator cast type to include `%` so the CLI passes a compatible operator union to `calculate`. (`src/index.ts:35`)

### `tests/unit.test.ts`
- Add a test case that asserts correct modulo behavior via `calculate`, e.g., `calculate(10, "%", 3)` yields `1`, aligning with JavaScript’s remainder operator. (`tests/unit.test.ts:4-19`)

### `tests/e2e.test.ts`
- Add an E2E CLI test for `calc` using `%` that asserts the CLI prints the numeric remainder only (similar to the existing `+` test). (`tests/e2e.test.ts:26-39`)

## Constraints and assumptions
- The request only indicates support for modulo; no changes to error handling, input validation, or division-by-zero behavior are specified. Existing CLI parsing and numeric coercion should remain intact. (`src/index.ts:15-31`, `src/cli.ts:5-15`)
- Modulo semantics follow JavaScript’s `%` operator (remainder), consistent with current arithmetic implementation. (`src/cli.ts:5-15`)

## External dependencies
- None required. Existing dependencies (`yargs`, `bun:test`) already cover CLI parsing and testing. (`package.json:1-19`)