### PR TITLE
fix: update hello output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
Updated the hello message source to return the new greeting and aligned the CLI e2e expectation with it, so the `hello` command now emits "Hello, World!" consistently.

**Details**
- `src/cli.ts` now exports the new `currentText` value used by the `hello` command.
- `tests/e2e.test.ts` asserts the updated greeting text.

**Tests**
- Not run (per instructions).

**Files changed**
- `src/cli.ts`
- `tests/e2e.test.ts`

## Specification
# Change Specification

## Request interpretation
The CLI's `hello` command currently prints "Hello via Bun!" via `currentText`; update outputs and tests so "Hello, World!" is printed instead. This is derived from the issue body because there are no comments to override it.

## Research findings
- `currentText` is defined as "Hello via Bun!" and is exported from `src/cli.ts`; it is the single source of the `hello` message. Source: `src/cli.ts:1`.
- The CLI `hello` command prints `currentText` to stdout. Source: `src/index.ts:6-12`.
- The end-to-end test asserts that the `hello` command outputs "Hello via Bun!". Source: `tests/e2e.test.ts:26-32`.
- The CLI is built with `yargs` and runs under Bun; no external API calls are involved for the hello output. Sources: `src/index.ts:1-43`, `package.json:15-17`.

## Required changes (WHAT to change)

### `src/cli.ts`
- Change the exported `currentText` string value from "Hello via Bun!" to "Hello, World!" so the `hello` command prints the new greeting. Source: `src/cli.ts:1`.

### `tests/e2e.test.ts`
- Update the `hello prints the current text` test expectation to match the new output "Hello, World!". Source: `tests/e2e.test.ts:26-32`.

## Notes and constraints
- No other files reference the greeting text; `currentText` is the only message source used by `hello`. Sources: `src/cli.ts:1`, `src/index.ts:6-12`.
- No external library documentation is required for this change.