### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo support across CLI validation and calculation logic, plus coverage in unit and e2e tests.
- Updated operator union/switch in `src/cli.ts` and CLI operator choices/cast in `src/index.ts`.
- Added modulo assertions in `tests/unit.test.ts` and `tests/e2e.test.ts`.

Tests not run (per instruction).

Next steps:
1. Run `bun test` if you want to verify locally.

## Specification
# Change Specification: Support Modulo Operator

## Request Interpretation
Add modulo (`%`) support alongside existing arithmetic operations in the CLI calculator. There are no comments overriding the issue body, so the request is interpreted as adding modulo support everywhere the operator set is defined or validated.

## Research Findings
- The CLI is implemented with yargs; the `calc` command restricts operators via `choices` and casts the operator type to `"+" | "-" | "*" | "/"`. `src/index.ts:15-37`.
- The operator union type is defined as `"+" | "-" | "*" | "/"` and the calculator uses a `switch` with those cases. `src/cli.ts:3-15`.
- Unit tests cover the four existing operations. `tests/unit.test.ts:4-19`.
- E2E tests exercise the CLI `calc` command using `+`. `tests/e2e.test.ts:34-38`.
- Dependencies: yargs is the only runtime dependency; no external libraries are involved in arithmetic. `package.json:16-18`.

## Specification (What to Change)

### `src/cli.ts`
- **Operator type definition**: Extend the `Operator` union to include the modulo operator `%` so the type reflects all supported operations. `src/cli.ts:3`.
- **Calculation logic**: Add a modulo branch to the `switch` so `calculate(left, "%", right)` returns the JavaScript remainder result. `src/cli.ts:5-15`.
- **Behavioral expectation**: Use standard JavaScript `%` semantics for remainder. No special error handling is currently implemented for division, so modulo should follow the same approach (e.g., `left % 0` yields `NaN`). `src/cli.ts:5-15`.

### `src/index.ts`
- **CLI operator validation**: Add `%` to the `choices` array for the `operator` positional argument so the CLI accepts modulo. `src/index.ts:23-26`.
- **Operator type cast**: Update the literal union used in the `operator` cast to include `%` to match the expanded `Operator` type. `src/index.ts:35`.
- **Command description (optional alignment)**: If the command description or help text enumerates the operators, ensure modulo is implied or explicitly mentioned; currently it is generic, so no text change is required unless desired for clarity. `src/index.ts:15-16`.

### `tests/unit.test.ts`
- **Unit coverage**: Add a test case for modulo to validate `calculate` returns the remainder for typical inputs (e.g., `10 % 3` yields `1`). `tests/unit.test.ts:4-19`.

### `tests/e2e.test.ts`
- **CLI coverage**: Add an e2e test case that runs `calc` with `%` and asserts the output is the remainder string (e.g., `calc 10 % 3` -> `1`). `tests/e2e.test.ts:34-38`.

## Non-Changes
- No new dependencies or external APIs are required; the `%` operator is built into JavaScript. `package.json:16-18`.
- No changes to `currentText` or other CLI commands are needed. `src/cli.ts:1`, `src/index.ts:6-13`.