### PR TITLE
feat: update hello output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+  expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
Updated the CLI hello text to "Hello, World!" and aligned the end-to-end expectation with the new output.

- Updated `src/cli.ts` to export the new literal and ensured `tests/e2e.test.ts` asserts the same output.
- Tests not run (per instructions).

## Specification
# Change Specification

## Context and findings
- The CLI’s hello output is driven by the exported `currentText` constant in `src/cli.ts`, currently set to `"Hello via Bun!"`. (`src/cli.ts:1`)
- The `hello` command in `src/index.ts` prints `currentText` directly to stdout via `console.log`. (`src/index.ts:5`-`src/index.ts:12`)
- The end-to-end test asserts the hello command stdout equals `"Hello via Bun!"`, matching the current constant. (`tests/e2e.test.ts:26`-`tests/e2e.test.ts:32`)
- The CLI is built with `yargs`, but the hello command has no additional formatting or transformation beyond printing `currentText`. (`src/index.ts:1`-`src/index.ts:13`)

## Changes by file
- `src/cli.ts`: In the `currentText` constant definition, change the literal value from `"Hello via Bun!"` to `"Hello, World!"` to meet the new output requirement. (`src/cli.ts:1`)
- `tests/e2e.test.ts`: In the `hello prints the current text` test, update the expected stdout string to `"Hello, World!"` so the test aligns with the new requirement. (`tests/e2e.test.ts:27`-`tests/e2e.test.ts:32`)

## External dependencies
- No new libraries or external APIs are required for this change. Existing usage of `yargs` and Bun test utilities remains unchanged. (`src/index.ts:1`-`src/index.ts:43`, `tests/e2e.test.ts:1`-`tests/e2e.test.ts:40`)