### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo operator support across the CLI and core calculation path so `%` is accepted and evaluated with JavaScript remainder semantics.

- `src/cli.ts` extends `Operator` and handles `%` in `calculate`.
- `src/index.ts` allows `%` in yargs choices and operator typing for the CLI handler.
- `tests/unit.test.ts` and `tests/e2e.test.ts` cover modulo behavior at unit and CLI levels.

Tests not run (per instructions).

Next steps you may want:
1. Run `bun test`.

## Specification
# Change Specification: Support Modulo Operator

## Scope and context
- The CLI exposes a `calc` command that accepts `<left> <operator> <right>` and constrains `operator` to the set `["+", "-", "*", "/"]` via `yargs` choices, then passes that operator into `calculate` in `src/cli.ts` (see `src/index.ts:15-38`).
- Core arithmetic lives in `calculate`, which is a switch over a union type `Operator = "+" | "-" | "*" | "/"` and returns the corresponding JS arithmetic result (see `src/cli.ts:3-15`).
- Unit tests verify the four operators at the `calculate` level (see `tests/unit.test.ts:4-19`) and a single CLI case verifies output for `+` (see `tests/e2e.test.ts:34-38`).
- Dependencies include `yargs` for CLI argument parsing (see `package.json:18-20`).

## Requested behavior
- The calculator must accept the modulo operator alongside the four existing arithmetic operators. Interpret modulo as JavaScript’s remainder operator (`%`) applied to `left` and `right` numbers.

## File-by-file changes

### `src/cli.ts`
- Extend the `Operator` union to include the modulo operator (currently `+ - * /`) so `%` is recognized as a valid operator type (see `src/cli.ts:3`).
- Extend the `calculate` switch to return the remainder result for the modulo operator, consistent with JavaScript `%` semantics on numbers (see `src/cli.ts:5-14`).

### `src/index.ts`
- Expand the CLI `operator` positional argument choices to include `%`, keeping the existing choices array behavior (see `src/index.ts:23-27`).
- Broaden the local `operator` type assertion to include `%` so the CLI handler can pass it to `calculate` (see `src/index.ts:35-37`).

### `tests/unit.test.ts`
- Add a unit test case that validates modulo behavior through `calculate`, asserting the expected numeric remainder for a simple pair (e.g., `calculate(10, "%", 3) === 1`) to cover the new operator (see `tests/unit.test.ts:4-19`).

### `tests/e2e.test.ts`
- Add a CLI e2e test for modulo usage to ensure `calc` accepts `%` and prints only the numeric result string, similar to the existing `+` case (see `tests/e2e.test.ts:34-38`).

## Notes and constraints
- The CLI is strict and uses yargs `choices` for validation, so `%` must be explicitly listed or the command will reject it (see `src/index.ts:23-27`).
- There is no default case in `calculate`; adding `%` to the `Operator` union and switch keeps TypeScript exhaustiveness aligned with the CLI constraints (see `src/cli.ts:3-15`).
- No external libraries or APIs are needed for modulo; JavaScript’s built-in `%` operator is sufficient.