### PR TITLE
feat: update hello output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
Updated CLI hello text to "Hello, World!" and aligned the e2e expectation.

- `src/cli.ts`: set `currentText` to the new output string.
- `tests/e2e.test.ts`: updated the hello test expectation.

Tests not run (per instructions).

## Specification
**Change Spec**

**Context And Findings**
- The CLI's `hello` command prints `currentText` from `src/cli.ts` via `console.log(currentText)` in `src/index.ts` (`src/index.ts:6-12`).
- `currentText` is currently the string "Hello via Bun!" in `src/cli.ts:1`.
- The end-to-end test asserts the `hello` command stdout equals "Hello via Bun!" in `tests/e2e.test.ts:27-32`.
- No other occurrences of "Hello" were found in the repository besides these two locations (`src/cli.ts:1`, `tests/e2e.test.ts:31`).
- No external APIs or libraries are needed for the requested text change; the behavior is local to the CLI string constant and tests.

**Per-File Change Requirements**
- `src/cli.ts`: Update the `currentText` constant to the new required output string "Hello, World!" so the `hello` command prints the requested text (`src/cli.ts:1`).
- `tests/e2e.test.ts`: Update the `hello prints the current text` expectation to match the new output string "Hello, World!" to keep the CLI test aligned with the new behavior (`tests/e2e.test.ts:27-32`).

**Behavioral Expectations**
- Invoking the CLI with `hello` should print exactly "Hello, World!" with no additional output, consistent with how `currentText` is printed today (`src/index.ts:6-12`).
- Existing `calc` behavior and tests remain unchanged (`src/index.ts:14-38`, `tests/e2e.test.ts:34-38`).