### PR TITLE
feat: update hello output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
Updated the hello output constant and kept the E2E expectation in sync with the new "Hello, World!" text to ensure runtime and test alignment in `src/cli.ts` and `tests/e2e.test.ts`.

- `src/cli.ts`: switch `currentText` to "Hello, World!" so the CLI prints the requested phrase.
- `tests/e2e.test.ts`: update the hello command assertion to expect the new output.

- Tests not run (per request).

## Specification
# Change Specification: Print "Hello, World!"

## Request Summary
Update the CLI "hello" output to print "Hello, World!" instead of the current "Hello via Bun!" string used throughout the codebase. The "hello" command prints the `currentText` constant from the CLI module, and the E2E test asserts the same value. No additional comments override the request.

## Research Findings
- The CLI text for the hello command is defined as `currentText` in `src/cli.ts` and currently equals "Hello via Bun!". This constant is the source of truth for the hello output. `src/cli.ts:1`.
- The command-line entrypoint uses `currentText` when executing the `hello` command, so changing the constant will change runtime output. `src/index.ts:3`, `src/index.ts:10-12`.
- The E2E test for the hello command asserts the current output is "Hello via Bun!" and will need to reflect the new string. `tests/e2e.test.ts:26-32`.

## Change Requirements (What to Change)

### `src/cli.ts`
- Update the `currentText` string value to "Hello, World!" so the hello command prints the requested phrase. This is the canonical text source for the CLI output. `src/cli.ts:1`.

### `tests/e2e.test.ts`
- Update the hello command assertion to expect the new output "Hello, World!" to keep the E2E test aligned with the updated CLI string. `tests/e2e.test.ts:27-32`.

## Notes
- No external APIs or libraries are required for this change; the code already emits the string via `console.log` and is wired through `currentText`. `src/index.ts:10-12`.
- No other references to "Hello via Bun!" exist outside the CLI constant and its test assertion. `src/cli.ts:1`, `tests/e2e.test.ts:31`.