### PR TITLE
fix: print Hello, World in hello

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
Updated the CLI hello output to use the new "Hello, World!" constant and aligned the e2e expectation with it in `src/cli.ts` and `tests/e2e.test.ts`.

- Changes: `src/cli.ts`, `tests/e2e.test.ts`
- Tests: not run (per instructions)
- Commit: `fix: print Hello, World in hello`
- Push: `git push origin HEAD`

## Specification
# Change Specification: Print "Hello, World!" in CLI

## Scope and intent
- The request targets the CLI "hello" command output, which currently prints a constant string defined in `src/cli.ts` and used in `src/index.ts`. The expectation is also asserted in the e2e tests. No other modules or outputs reference the literal string. [src/cli.ts:1], [src/index.ts:3-12], [tests/e2e.test.ts:26-32]

## Research findings
- The CLI defines a `currentText` constant in `src/cli.ts` with the value "Hello via Bun!". This constant is exported for use elsewhere. [src/cli.ts:1]
- The CLI's `hello` command logs `currentText` to stdout via `console.log`. [src/index.ts:6-12]
- The e2e test for the `hello` command asserts that stdout equals "Hello via Bun!" after trimming. [tests/e2e.test.ts:27-32]
- No other references to the "Hello via Bun!" literal or the `currentText` constant exist in the repo besides these files. [src/cli.ts:1], [src/index.ts:3-12], [tests/e2e.test.ts:27-32]

## Change specification (WHAT to change)
- `src/cli.ts`: Update the `currentText` constant value to exactly "Hello, World!" so the CLI "hello" command prints the requested text. [src/cli.ts:1]
- `tests/e2e.test.ts`: Update the `hello prints the current text` assertion to expect "Hello, World!" to match the new output. [tests/e2e.test.ts:27-32]

## Constraints and notes
- No external libraries or APIs are required for this change; the output is a direct string constant used by the CLI. [src/cli.ts:1], [src/index.ts:6-12]