### PR TITLE
feat: update hello greeting

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
Updated the CLI greeting to print "Hello, World!" and matched the e2e expectation for the hello command output.
- Swapped the exported greeting constant in `src/cli.ts` to the new text so `hello` uses it.
- Aligned the hello output assertion in `tests/e2e.test.ts` with the new message.
- Tests not run (per instruction).

Next steps:
1. Run `bun test` if you want to verify locally.

## Specification
# Change Specification: print "Hello, World!" instead of "Hello via Bun!"

## Scope and intent
The CLI `hello` command currently prints the `currentText` string from `src/cli.ts`, and the end-to-end test asserts that exact output. The request is to change the printed greeting to `"Hello, World!"`.

## Research findings
- The `hello` command is defined in `src/index.ts` and prints `currentText` from `src/cli.ts` via `console.log(currentText);` (`src/index.ts:5-12`).
- The greeting string is defined as `export const currentText = "Hello via Bun!";` in `src/cli.ts:1`.
- The e2e test asserts the current `hello` output as `"Hello via Bun!"` (`tests/e2e.test.ts:26-32`).
- No other tests reference the greeting string; unit tests cover only `calculate` (`tests/unit.test.ts:1-19`).
- The project uses Bun and yargs, but no external API calls or documentation are required for this string change.

## Required changes (WHAT to change)
- `src/cli.ts`: Update the `currentText` constant to the new greeting string `"Hello, World!"` so the CLI uses the new message (`src/cli.ts:1`).
- `tests/e2e.test.ts`: Update the `hello prints the current text` expectation to match `"Hello, World!"` (`tests/e2e.test.ts:27-32`).

## Notes and constraints
- The `hello` command is the only consumer of `currentText` (`src/index.ts:5-12`), so updating the constant is sufficient to change output.
- Keep the change limited to the greeting text; no other CLI behavior or calculation logic should be altered.