### PR TITLE
fix: update hello output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
- Updated `currentText` to print `Hello, World!` for the CLI output in `src/cli.ts`.
- Aligned the hello CLI end-to-end test expectation with the new output in `tests/e2e.test.ts`.

Tests not run (per instructions).

## Specification
# Change Specification: Print "Hello, World!"

## Scope and intent
Update the CLI "hello" output to print `Hello, World!` instead of `Hello via Bun!`, and align tests with the new output. The existing CLI command wiring uses `currentText` for output, so the change must update the source of that value and any tests asserting the previous string.

## Research findings
- The CLI command `hello` prints `currentText` from `src/cli.ts` when invoked (`console.log(currentText)`), so the displayed text is controlled by the exported constant (`src/index.ts:5-12`).
- The value of `currentText` is currently set to `"Hello via Bun!"` (`src/cli.ts:1`).
- The end-to-end test asserts the exact output string for `hello` and currently expects `Hello via Bun!` (`tests/e2e.test.ts:26-32`).
- No other files reference the greeting string; unit tests only cover `calculate` (`tests/unit.test.ts:1-20`).

## Required changes by file
- `src/cli.ts`: Update the exported `currentText` value to exactly `"Hello, World!"` so the CLI output matches the request (`src/cli.ts:1`).
- `tests/e2e.test.ts`: Update the `hello prints the current text` assertion to expect `"Hello, World!"` to keep the test aligned with the new output (`tests/e2e.test.ts:26-32`).

## Notes and constraints
- No external APIs or libraries are required for this change; the output is a static string managed in `src/cli.ts` and consumed in `src/index.ts`.
- Ensure the string matches the requested punctuation and casing (`Hello, World!`) precisely.