### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo support end-to-end: extended the operator type and calculate switch, expanded CLI operator validation/typing, and covered `%` in unit and CLI tests.

Details:
- Updated operator union and calculate dispatch in `src/cli.ts` to include `%`.
- Allowed `%` in the CLI positional choices and operator typing in `src/index.ts`.
- Added modulo coverage in `tests/unit.test.ts` and `tests/e2e.test.ts`.

Tests not run (per instruction).

## Specification
# Change Specification: Support Modulo Operator

## Scope and intent
Add modulo (`%`) as a supported arithmetic operator in the CLI calculator alongside `+`, `-`, `*`, and `/`. This includes the operator type/dispatch, CLI argument validation, and tests that cover modulo behavior. No external libraries or APIs are required.

## Research findings
- The calculator logic is centralized in `calculate`, which accepts a strict `Operator` union of `"+" | "-" | "*" | "/"` and dispatches via `switch` with one case per operator. There is no default case, so unsupported operators are currently impossible by type restriction. `src/cli.ts:3-15`.
- The CLI uses `yargs` with a `calc <left> <operator> <right>` command and restricts `operator` to choices `"+"`, `"-"`, `"*"`, `"/"`. The parsed `operator` is cast to the same union type used by `calculate`. `src/index.ts:15-37`.
- Unit tests cover four operations through `calculate` only. `tests/unit.test.ts:4-19`.
- End-to-end CLI tests only validate `calc` with addition and `hello`. `tests/e2e.test.ts:26-39`.

## Required changes by file

### `src/cli.ts`
- **Operator type**: Extend the `Operator` union to include `%`, so modulo is treated as a first-class supported operator. `src/cli.ts:3`.
- **calculate switch**: Add a `%` case that returns the JavaScript remainder of `left % right`. Keep behavior consistent with existing arithmetic operations. `src/cli.ts:5-15`.

### `src/index.ts`
- **CLI operator validation**: Extend the `choices` array for the `operator` positional argument to include `%` so the CLI accepts modulo input. `src/index.ts:23-27`.
- **Operator typing**: Update the local `operator` cast type to include `%`, consistent with the updated `Operator` type. `src/index.ts:35`.

### `tests/unit.test.ts`
- **New modulo test**: Add a unit test for modulo in the `calculate` suite, asserting a simple case (e.g., `calculate(10, "%", 3)` returns `1`). Mirror the existing style used for other operations. `tests/unit.test.ts:4-19`.

### `tests/e2e.test.ts`
- **New CLI modulo test**: Add an end-to-end test ensuring `calc` accepts `%` and prints the numeric result only, consistent with the existing addition test. Use a deterministic modulo example (e.g., `10 % 3` -> `1`). `tests/e2e.test.ts:26-39`.

## Notes and constraints
- There are no external dependencies or APIs involved; the modulo operation should use built-in JavaScript `%` behavior.
- Preserve the strict `yargs` validation pattern (`choices`) and the current output format (stdout only the numeric result).

## Sources
- `src/cli.ts:3-15`
- `src/index.ts:15-37`
- `tests/unit.test.ts:4-19`
- `tests/e2e.test.ts:26-39`