### PR TITLE
feat: add modulo operator support to calculator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc modulo prints the remainder", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary: Support Modulo Operator

## Overview
Added support for the modulo operator (`%`) to the calculator application, extending the existing four arithmetic operations (addition, subtraction, multiplication, division).

## Files Changed

### `src/cli.ts`
- Updated `Operator` type union to include `"%"`
- Added new case in `calculate` switch statement for `"%"` that returns `left % right`

### `src/index.ts`
- Added `"%"` to the yargs choices array for the operator positional argument
- Imported `Operator` type from `./cli` and used it in the type assertion for cleaner code

### `tests/unit.test.ts`
- Added unit test for modulo operation: `calculate(10, "%", 3)` should equal `1`

### `tests/e2e.test.ts`
- Added E2E test for modulo via CLI: `calc 10 % 3` should output `1`

## Commit
- Commit message: `feat: add modulo operator support to calculator`
- Branch pushed to: `origin/o-agents/issue-4-20260120-150323_0919-2`

## Specification
# Change Specification: Support Modulo Operator

## Overview

Add support for the modulo operator (`%`) to the calculator application, extending the existing four arithmetic operations (addition, subtraction, multiplication, division).

## Research Findings

### Current Implementation

The calculator is a TypeScript/Bun CLI application using yargs for command-line argument parsing. Arithmetic operations are implemented in two main files:

**Core Logic** (`src/cli.ts`):
- `Operator` type defined at line 3: `export type Operator = "+" | "-" | "*" | "/";`
- `calculate` function at lines 5-16 uses a switch statement to handle each operator

**CLI Interface** (`src/index.ts`):
- Operator choices defined at line 25: `choices: ["+", "-", "*", "/"] as const`
- Type assertion at line 35: `const operator = argv.operator as "+" | "-" | "*" | "/";`

**Tests**:
- Unit tests in `tests/unit.test.ts` lines 4-20 test each operator
- E2E tests in `tests/e2e.test.ts` test CLI invocation

### Pattern to Follow

Each operator follows a consistent pattern:
1. Included in the `Operator` type union
2. Has a case in the `calculate` switch statement
3. Listed in yargs choices array
4. Included in the type assertion
5. Has corresponding unit test(s)

---

## File Changes Required

### `src/cli.ts`

**Type Definition (line 3)**
- Current: `export type Operator = "+" | "-" | "*" | "/";`
- Change: Add `"%"` to the union type

**Calculate Function (lines 5-16)**
- Current: Switch statement handles `+`, `-`, `*`, `/`
- Change: Add a new case for `"%"` that returns `left % right` (JavaScript's native modulo operator)

---

### `src/index.ts`

**Operator Choices (line 25)**
- Current: `choices: ["+", "-", "*", "/"] as const`
- Change: Add `"%"` to the choices array

**Type Assertion (line 35)**
- Current: `const operator = argv.operator as "+" | "-" | "*" | "/";`
- Change: Add `"%"` to the type assertion, or reference the imported `Operator` type for consistency

---

### `tests/unit.test.ts`

**Test Suite (lines 4-20)**
- Current: Contains tests for adds, subtracts, multiplies, divides
- Change: Add a new test case for modulo operation (e.g., `calculate(10, "%", 3)` should equal `1`)

---

### `tests/e2e.test.ts` (optional but recommended)

**CLI Tests (lines 26-40)**
- Current: Tests hello command and calc with addition
- Change: Consider adding an E2E test for modulo to verify CLI integration

---

## Technical Notes

- JavaScript's `%` operator performs remainder calculation (not true mathematical modulo for negative numbers)
- No external libraries required; uses native JavaScript operator
- The modulo operator has the same precedence considerations as multiplication/division in standard arithmetic, but since this calculator only handles single binary operations, operator precedence is not a concern

## References

- `src/cli.ts:3` - Operator type definition
- `src/cli.ts:5-16` - calculate function
- `src/index.ts:25` - yargs choices array
- `src/index.ts:35` - operator type assertion
- `tests/unit.test.ts:4-20` - unit test suite
- `tests/e2e.test.ts:34-39` - E2E calc test