### PR TITLE
fix: update hello output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
**Changes**
- Updated `currentText` to print `Hello, World!` in the `hello` command.
- Adjusted the hello CLI end-to-end test to expect the new output.

**Testing**
- Not run (per instructions).

## Specification
# Change Specification: print "Hello, World!" in hello command

## Context and research findings
- The `hello` CLI command prints `currentText` from `src/cli.ts` via `console.log(currentText)` in the command handler (`src/index.ts:1-43`).
- `currentText` is currently the string `"Hello via Bun!"` (`src/cli.ts:1`).
- The end-to-end test asserts the `hello` command outputs `"Hello via Bun!"` (`tests/e2e.test.ts:26-32`).
- No comments exist in the issue request, so the body requirement to print `"Hello, World!"` is the sole driver.
- No external APIs or libraries are required for this change; it is a local string update and test expectation update.

## Specification of changes (WHAT to change)

### `src/cli.ts`
- Update the `currentText` constant value to `"Hello, World!"` so the `hello` command prints the requested text (`src/cli.ts:1`).

### `tests/e2e.test.ts`
- Update the `hello prints the current text` test to expect `"Hello, World!"` as stdout so the test matches the new `currentText` output (`tests/e2e.test.ts:26-32`).

## Expected behavior after change
- Running the `hello` command should print exactly `Hello, World!` with no additional text, while all other commands (e.g., `calc`) remain unchanged (`src/index.ts:5-38`, `src/cli.ts:3-15`).