### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "5", "%", "2"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(5, "%", 2)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Implemented modulo operator support in calculation logic and CLI parsing, plus added unit and e2e coverage for `%` in `src/cli.ts`, `src/index.ts`, `tests/unit.test.ts`, and `tests/e2e.test.ts`.

Tests not run (per instructions).

## Specification
# Change Specification: Support Modulo Operator

## Scope and intent
Support a modulo operator (`%`) alongside the existing four arithmetic operators for the CLI calculator. The codebase currently exposes calculation logic in `src/cli.ts` and a yargs-based CLI command `calc` in `src/index.ts`, with unit and e2e tests covering the four current operators. (`src/cli.ts:1-15`, `src/index.ts:1-43`, `tests/unit.test.ts:1-20`, `tests/e2e.test.ts:1-39`)

## Research findings (current behavior and structure)
- Calculation logic is centralized in `calculate(left, operator, right)` with a TypeScript union type `Operator = "+" | "-" | "*" | "/"` and a `switch` over the operator string. (`src/cli.ts:3-15`)
- The CLI uses yargs with a `calc <left> <operator> <right>` command. The `operator` positional is constrained to `choices: ["+", "-", "*", "/"]`, and the parsed operator is cast to the same union type. (`src/index.ts:15-37`)
- Tests validate calculator behavior for the four operators in unit tests and the CLI output for `calc 2 + 3` in e2e tests. (`tests/unit.test.ts:4-19`, `tests/e2e.test.ts:26-39`)
- No additional documentation or usage examples for `calc` are present in the README. (`README.md:1-13`)

## Changes required (by file)

### `src/cli.ts`
- **Operator type**: Expand the `Operator` union to include the modulo operator `%` so it is recognized as a valid operator for `calculate`. (`src/cli.ts:3`)
- **Calculate behavior**: Add handling for the `%` operator in the `switch` so it returns the JavaScript remainder (`left % right`) when `%` is provided. (`src/cli.ts:5-15`)

### `src/index.ts`
- **CLI operator choices**: Include `%` in the yargs `choices` list for the `operator` positional to accept modulo from the CLI. (`src/index.ts:23-27`)
- **Operator typing**: Update the local `operator` type cast to include `%` to align with the expanded `Operator` union. (`src/index.ts:35`)

### `tests/unit.test.ts`
- **Unit coverage**: Add a unit test that asserts `calculate` returns the expected remainder when given `%`. Choose a representative example (e.g., `5 % 2` yields `1`) to match JavaScript remainder semantics. (`tests/unit.test.ts:4-19`, `src/cli.ts:5-15`)

### `tests/e2e.test.ts`
- **CLI coverage**: Add an e2e test for the `calc` command that uses `%` and asserts stdout equals the expected remainder (string). This ensures yargs parsing and the CLI path accepts `%`. (`tests/e2e.test.ts:26-39`, `src/index.ts:15-37`)

## Notes and constraints
- No external libraries are required; modulo is a built-in JavaScript operator, and the CLI already depends on yargs for argument parsing. (`src/cli.ts:5-15`, `src/index.ts:15-37`)
- Maintain the existing CLI interface (`calc <left> <operator> <right>`) and output format (number-only). (`src/index.ts:15-38`, `tests/e2e.test.ts:34-39`)