### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo support end-to-end by extending the operator union and calculation logic, and wired the CLI parser/operator typing to accept `%` under strict yargs parsing. Updated coverage to include modulo in both unit and CLI tests to match existing expectations.

- Updated `src/cli.ts` to support `%` in the `Operator` type and switch branch.
- Updated `src/index.ts` to accept `%` in yargs choices and operator typing.
- Added modulo test coverage in `tests/unit.test.ts` and `tests/e2e.test.ts`.
- Tests not run (per instructions).
- Pushed branch `o-agents/issue-4-20260120-205727_0716-1` to origin.

## Specification
# Change Specification: Support Modulo Operator

## Request Interpretation
Support the modulo operator in addition to the existing four arithmetic operators. No comments override the issue body, so the request is to accept `%` as an operator in the CLI and in the calculation logic.

## Repository Findings
- CLI entrypoint uses yargs with a `calc <left> <operator> <right>` command and restricts `operator` to `choices: ["+", "-", "*", "/"]` and casts the operator to a union type before calling `calculate`. `strict()` is enabled. (src/index.ts:15-42)
- Core arithmetic is implemented in `calculate` with a `Operator` union type limited to `+`, `-`, `*`, `/` and a switch that returns for each of those operators. (src/cli.ts:3-15)
- Unit tests cover the four current operators only. (tests/unit.test.ts:4-19)
- E2E test validates `calc 2 + 3` output. (tests/e2e.test.ts:26-39)
- No external arithmetic libraries are used; runtime is Bun with yargs for CLI parsing. (src/index.ts:1-42)

## Change Specification (WHAT to change)

### `src/cli.ts`
- **Operator type definition**: Extend the `Operator` union to include the modulo operator `%` so it is part of the accepted operator set. (src/cli.ts:3)
- **Calculation logic**: Add a branch in `calculate` that returns the modulo (remainder) result when `operator` is `%`. This must align with JavaScript’s remainder behavior for numbers. (src/cli.ts:5-15)

### `src/index.ts`
- **CLI operator choices**: Update the yargs `operator` positional `choices` array to include `%` so the CLI accepts it under `strict()` mode. (src/index.ts:23-27)
- **Operator typing**: Update the local operator type cast used when calling `calculate` to include `%`, matching the updated `Operator` type. (src/index.ts:33-37)

### `tests/unit.test.ts`
- **Unit coverage**: Add a unit test for modulo in the `calculate` describe block to verify `%` produces the expected remainder. (tests/unit.test.ts:4-19)

### `tests/e2e.test.ts`
- **CLI coverage**: Add an end-to-end test that invokes `calc` with `%` and asserts the output is only the numeric remainder string, mirroring existing CLI expectations. (tests/e2e.test.ts:34-39)

## Dependencies and Constraints
- **CLI parsing**: Because `yargs` uses `choices` and `strict()` (src/index.ts:23-42), `%` must be explicitly added to the choices list or the CLI will reject it.
- **Arithmetic semantics**: No external libraries are present; modulo should follow JavaScript number remainder semantics (`left % right`). (src/cli.ts:5-15)
- **Testing style**: Tests use Bun’s `bun:test` APIs. New tests should follow the existing structure and expectations. (tests/unit.test.ts:1-19, tests/e2e.test.ts:1-39)

## External Research
- No external libraries or APIs are required for modulo support; existing arithmetic uses native JavaScript operators. No external documentation needed.