### PR TITLE
feat: add modulo operator support to calculator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc modulo prints the remainder", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary: Support Modulo Operator

## Overview
Added support for the modulo operator (`%`) to the CLI-based calculator, extending the existing arithmetic operations (`+`, `-`, `*`, `/`).

## Files Modified

### `src/cli.ts`
- Extended the `Operator` type union to include `"%"`
- Added a new case in the `calculate` function's switch statement to handle modulo operations

### `src/index.ts`
- Added `"%"` to the `choices` array in the operator positional argument
- Updated the type cast for the operator to include `"%"`

### `tests/unit.test.ts`
- Added a new unit test for the modulo operation (`calculate(10, "%", 3)` returns `1`)

### `tests/e2e.test.ts`
- Added a new e2e test for the modulo operation via CLI (`calc 10 % 3` outputs `1`)

## Commit
```
feat: add modulo operator support to calculator

Add support for the modulo operator (%) to perform remainder calculations.
This extends the existing arithmetic operations (+, -, *, /).

Co-authored-by: DuelingAgents-Bot <bot@dueling-agents.com>
```

## Branch
Pushed to `origin/o-agents/issue-4-20260123-014712_0534-2`

## Specification
# Change Specification: Support Modulo Operator

## Summary

Add support for the modulo operator (`%`) to the existing calculator functionality, which currently supports addition (`+`), subtraction (`-`), multiplication (`*`), and division (`/`).

---

## Research Findings

### Current Implementation Structure

The project is a CLI-based calculator using yargs for argument parsing. The arithmetic operations are implemented in two files:

1. **`src/cli.ts`** - Core calculation logic
   - Exports the `Operator` type union: `"+" | "-" | "*" | "/"` (line 3)
   - Exports the `calculate` function that uses a switch statement to perform operations (lines 5-16)

2. **`src/index.ts`** - CLI entry point using yargs
   - Defines the `calc` command with positional arguments: `left`, `operator`, `right` (lines 15-38)
   - The `operator` positional has `choices` constraint: `["+", "-", "*", "/"]` (line 25)
   - Type casts the operator to the `Operator` type (line 35)

### Test Coverage

1. **`tests/unit.test.ts`** - Unit tests for the `calculate` function
   - Tests each operator: addition, subtraction, multiplication, division (lines 5-19)

2. **`tests/e2e.test.ts`** - End-to-end CLI tests
   - Tests the `calc` command with addition (lines 34-39)

### Dependencies

- **yargs** (v18.0.0) - CLI argument parser
  - Used for command definition and argument validation
  - The `choices` array restricts allowed operator values

---

## Changes Required

### File: `src/cli.ts`

**Location: Line 3 - Operator type definition**
- Add `"%"` to the `Operator` type union

**Location: Lines 5-16 - calculate function**
- Add a new case in the switch statement for the `"%"` operator that returns `left % right`

---

### File: `src/index.ts`

**Location: Line 25 - operator choices array**
- Add `"%"` to the `choices` array constraint

**Location: Line 35 - type cast**
- Update the type cast to include `"%"` in the union type

---

### File: `tests/unit.test.ts`

**Location: After line 19 - unit tests**
- Add a new test case for the modulo operation (e.g., `calculate(10, "%", 3)` should return `1`)

---

### File: `tests/e2e.test.ts` (optional but recommended)

**Location: After line 39 - e2e tests**
- Add a new test case for the modulo operation via CLI (e.g., `["calc", "10", "%", "3"]` should output `1`)

---

## Constraints and Considerations

- The modulo operator in JavaScript (`%`) returns the remainder of integer division
- For negative numbers, JavaScript's `%` operator follows the sign of the dividend (e.g., `-10 % 3` returns `-1`)
- No external libraries are required; the native JavaScript `%` operator provides the needed functionality