### PR TITLE
fix: update hello output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
Updated the hello text to "Hello, World!" and kept the e2e assertion aligned with the CLI output.
- `src/cli.ts`: changed `currentText` so the hello command prints the requested string.
- `tests/e2e.test.ts`: updated the hello expectation to match the new output.
- Tests not run (per instructions).

## Specification
# Change Specification

## Request interpretation
- The issue asks to print "Hello, World!" instead of "Hello via Bun!" and there are no comments to override that request.

## Research findings
- The CLI's hello command prints the `currentText` constant from `src/cli.ts`, which is currently set to "Hello via Bun!" (`src/cli.ts:1`, `src/index.ts:7-12`).
- The end-to-end test asserts that the `hello` command outputs "Hello via Bun!" (`tests/e2e.test.ts:27-32`).
- No other files reference the hello output string (`src/cli.ts:1`, `tests/e2e.test.ts:31`).
- The project uses Bun and yargs for CLI execution (`tests/e2e.test.ts:1-12`, `src/index.ts:1-5`), but the requested change does not require new dependencies or external APIs.

## Change specification (WHAT to change)

### `src/cli.ts`
- Update the `currentText` constant to be the exact string "Hello, World!" instead of "Hello via Bun!" so the hello command prints the requested text (`src/cli.ts:1`, `src/index.ts:7-12`).

### `tests/e2e.test.ts`
- Update the hello command expectation to match the new output string "Hello, World!" so the test continues to reflect the intended behavior (`tests/e2e.test.ts:27-32`).

## External dependencies
- None required for this change.