### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
Added modulo support end-to-end by extending the operator union, CLI choices, and calc handler typing to accept `%`, with a new switch branch using native remainder in `src/cli.ts` and CLI parsing updates in `src/index.ts`.

**Changes**
- Added `%` handling in calculation logic: `src/cli.ts`
- Allowed `%` in CLI operator choices and typing: `src/index.ts`
- Added modulo coverage in unit and e2e tests: `tests/unit.test.ts`, `tests/e2e.test.ts`

**Tests**
- Not run (per instructions)

## Specification
# Change Specification: Support Modulo Operator

## Scope and intent
Add modulo operator support alongside the existing arithmetic operators in the CLI calculator and its core calculation logic. The current implementation only handles `+`, `-`, `*`, `/` in both the CLI command parsing and the calculation function, and tests only cover those operations. This change extends the accepted operators and ensures both unit and end-to-end behavior are validated. Sources: `src/index.ts:15-37`, `src/cli.ts:3-15`, `tests/unit.test.ts:4-19`, `tests/e2e.test.ts:26-39`.

## Current behavior and structure (research findings)
- CLI command `calc <left> <operator> <right>` validates `operator` via `choices` and casts to a union of `+ | - | * | /` before calling `calculate`. Source: `src/index.ts:15-37`.
- Calculation logic uses a `Operator` type union of `+ | - | * | /` and a switch on the operator to return the result. Source: `src/cli.ts:3-15`.
- Unit tests validate `calculate` for add, subtract, multiply, divide only. Source: `tests/unit.test.ts:4-19`.
- E2E tests cover CLI output for `hello` and a single `calc` example. Source: `tests/e2e.test.ts:26-39`.
- No external libraries or APIs are required for arithmetic modulo beyond existing TypeScript/JavaScript operators; existing deps include `yargs` in CLI. Source: `src/index.ts:1-3`.

## Required changes by file (WHAT to change)

### `src/cli.ts`
- Extend the `Operator` type union to include the modulo operator `%` so that the calculation function type accepts it. Source: `src/cli.ts:3`.
- Add a `%` branch to the `calculate` switch to return the modulo result for `left % right` to mirror existing arithmetic handling. Source: `src/cli.ts:5-15`.

### `src/index.ts`
- Update the CLI `operator` positional argument `choices` to include `%` so the parser accepts modulo. Source: `src/index.ts:23-27`.
- Update the local operator type cast used in `calc` command handler to include `%` so the runtime type aligns with the expanded `Operator`. Source: `src/index.ts:35`.

### `tests/unit.test.ts`
- Add a test case that asserts `calculate` returns the expected modulo value for a representative input pair. Source: `tests/unit.test.ts:4-19`.

### `tests/e2e.test.ts`
- Add a CLI test that exercises `calc` with `%` and asserts the numeric stdout matches the modulo result, matching existing CLI test structure. Source: `tests/e2e.test.ts:26-39`.

## Constraints and assumptions
- Behavior should match JavaScript/TypeScript `%` operator semantics (remainder with sign of dividend), consistent with using the native operator in code. No extra validation or error handling is currently present for divide/modulo-by-zero, and this request does not require changing that behavior. Source: `src/cli.ts:5-15`.
- The CLI continues to accept only the enumerated operator choices; extending this list is the only required parser change. Source: `src/index.ts:23-27`.

## External dependencies
- None required; modulo is a built-in JavaScript operator and should be implemented using existing language constructs. Source: `src/cli.ts:5-15`.