### PR TITLE
refactor: replace yargs with commander

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "agent-benchmark",
       "dependencies": {
-        "yargs": "18.0.0",
+        "commander": "14.0.2",
       },
       "devDependencies": {
         "@types/bun": "1.3.5",
@@ -19,27 +19,15 @@
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
-    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+    "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
     "detect-indent": ["detect-indent@7.0.2", "", {}, "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A=="],
 
     "detect-newline": ["detect-newline@4.0.1", "", {}, "sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
-
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
-    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
-    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
     "git-hooks-list": ["git-hooks-list@4.1.1", "", {}, "sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA=="],
 
@@ -53,22 +41,10 @@
 
     "sort-package-json": ["sort-package-json@3.6.0", "", { "dependencies": { "detect-indent": "^7.0.2", "detect-newline": "^4.0.1", "git-hooks-list": "^4.1.1", "is-plain-obj": "^4.1.0", "semver": "^7.7.3", "sort-object-keys": "^2.0.1", "tinyglobby": "^0.2.15" }, "bin": { "sort-package-json": "cli.js" } }, "sha512-fyJsPLhWvY7u2KsKPZn1PixbXp+1m7V8NWqU8CvgFRbMEX41Ffw1kD8n0CfJiGoaSfoAvbrqRRl/DcHO8omQOQ=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
-
-    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
-
-    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
-
-    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "name": "agent-benchmark",
   "version": "1.0.0",
-  "private": true,
-  "description": "A benchmark for coding agents",
-  "repository": "github:exKAZUu/agent-benchmark",
-  "license": "UNLICENSED",
   "author": "Kazunori Sakamoto",
-  "type": "module",
+  "repository": "github:exKAZUu/agent-benchmark",
   "module": "src/index.ts",
   "devDependencies": {
     "@types/bun": "1.3.5",
     "sort-package-json": "3.6.0",
     "typescript": "5.9.3"
   },
+  "description": "A benchmark for coding agents",
+  "license": "UNLICENSED",
+  "private": true,
+  "type": "module",
   "dependencies": {
-    "yargs": "18.0.0"
+    "commander": "14.0.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,43 +1,23 @@
-import yargs from "yargs";
-import { hideBin } from "yargs/helpers";
+import { Command, Argument } from "commander";
 import { calculate, currentText } from "./cli";
 
-yargs(hideBin(process.argv))
-  .command(
-    "hello",
-    "Print the current text",
-    () => {},
-    () => {
-      console.log(currentText);
-    },
-  )
-  .command(
-    "calc <left> <operator> <right>",
-    "Calculate a result from two numbers and an operator",
-    (cmd) =>
-      cmd
-        .positional("left", {
-          type: "number",
-          demandOption: true,
-        })
-        .positional("operator", {
-          type: "string",
-          choices: ["+", "-", "*", "/"] as const,
-          demandOption: true,
-        })
-        .positional("right", {
-          type: "number",
-          demandOption: true,
-        }),
-    (argv) => {
-      const left = argv.left as number;
-      const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+const program = new Command();
 
-      console.log(calculate(left, operator, right));
-    },
-  )
-  .demandCommand(1)
-  .strict()
-  .help()
-  .parse();
+program
+  .command("hello")
+  .description("Print the current text")
+  .action(() => {
+    console.log(currentText);
+  });
+
+program
+  .command("calc")
+  .description("Calculate a result from two numbers and an operator")
+  .addArgument(new Argument('<left>', 'Left operand').argParser(parseFloat))
+  .addArgument(new Argument('<operator>', 'Operator').choices(['+', '-', '*', '/']))
+  .addArgument(new Argument('<right>', 'Right operand').argParser(parseFloat))
+  .action((left, operator, right) => {
+    console.log(calculate(left, operator, right));
+  });
+
+program.parse();


### PR DESCRIPTION
Closes #167

## Summary
# Change Summary

## Modified Files
- `package.json`: Replaced `yargs` with `commander`.
- `bun.lock`: Updated dependencies.
- `src/index.ts`: Refactored CLI argument parsing to use `commander`.

## Verification Results
- `bun run src/index.ts hello` -> Success
- `bun run src/index.ts calc 5 + 3` -> Success (Output: 8)
- `bun run src/index.ts calc 5 % 3` -> Correctly identified invalid operator.

## Specification
# Change Specification: Replace `yargs` with `commander`

## Overview
This specification details the steps to replace the `yargs` library with `commander` for CLI argument parsing. The goal is to maintain the existing CLI functionality (`hello` and `calc` commands) while switching the underlying library.

## Dependencies

### `package.json`
- **Remove**: `yargs`
- **Add**: `commander` (latest version)

## Files to Modify

### `src/index.ts`

**Current State**:
- Imports `yargs` and `hideBin`.
- Configures two commands: `hello` and `calc`.
- `calc` takes positional arguments `left` (number), `operator` (string with choices), and `right` (number).
- Uses `.demandCommand(1)`, `.strict()`, `.help()`, and `.parse()`.

**Changes Required**:
1.  **Imports**:
    -   Remove `import yargs from "yargs";` and `import { hideBin } from "yargs/helpers";`.
    -   Add `import { Command, Argument } from "commander";`.
    -   Keep `import { calculate, currentText } from "./cli";`.

2.  **CLI Initialization**:
    -   Instantiate a new `Command` object (e.g., `const program = new Command();`).

3.  **Command: `hello`**:
    -   Implement the `hello` command using `.command('hello')`.
    -   Set description to `"Print the current text"`.
    -   Set action to log `currentText`.

4.  **Command: `calc`**:
    -   Implement the `calc` command.
    -   Set description to `"Calculate a result from two numbers and an operator"`.
    -   **Arguments**:
        -   Define `left` argument:
            -   Use `new Argument('<left>', 'Left operand')`.
            -   Apply parser to convert to number: `.argParser(parseFloat)`.
        -   Define `operator` argument:
            -   Use `new Argument('<operator>', 'Operator')`.
            -   Restrict choices: `.choices(['+', '-', '*', '/'])`.
        -   Define `right` argument:
            -   Use `new Argument('<right>', 'Right operand')`.
            -   Apply parser to convert to number: `.argParser(parseFloat)`.
    -   **Action**:
        -   The action callback will receive parsed arguments: `(left, operator, right) => { ... }`.
        -   Call `console.log(calculate(left, operator, right));`.

5.  **Execution**:
    -   Call `program.parse()` at the end to parse `process.argv`.

## Research Findings & Implementation Details

-   **Commander Documentation**: [https://github.com/tj/commander.js](https://github.com/tj/commander.js)
-   **Argument Parsing**:
    -   Unlike `yargs`, `commander` arguments are strings by default.
    -   Use `.argParser(fn)` to transform arguments (e.g., `parseFloat` for numbers).
    -   Reference: `src/index.ts` currently expects numbers for `left` and `right`.
-   **Validation**:
    -   `yargs` `choices` equivalent in `commander` is `.choices([])` on the `Argument` object.
    -   Reference: `src/index.ts:19` defines choices `["+", "-", "*", "/"]`.
-   **Strict Mode**:
    -   `commander` errors on unknown commands by default, similar to `yargs.strict()`.

## Verification
-   Run `bun run src/index.ts hello` to verify the `hello` command.
-   Run `bun run src/index.ts calc 5 + 3` to verify the `calc` command.
-   Run `bun run src/index.ts calc 5 % 3` to verify invalid operator handling.