### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
- Added `%` to the operator union, calculation switch, and CLI choices so modulo is accepted and computed.
- Added unit and CLI e2e tests to cover modulo behavior.

Tests: `bun test tests/unit.test.ts tests/e2e.test.ts`

## Specification
# Specification: Support modulo operator

## Context and research findings
- CLI uses `yargs` to parse commands and restricts operator choices to `+`, `-`, `*`, `/` in `src/index.ts:15-38`.
- Core arithmetic is implemented in `calculate` with a discriminated `Operator` union and `switch` in `src/cli.ts:3-15`.
- Tests cover unit arithmetic and CLI output for `calc` in `tests/unit.test.ts:1-20` and `tests/e2e.test.ts:1-38`.
- No external libraries required for modulo; the `%` operator is native to JavaScript/TypeScript. No new dependencies.

## Required changes by file

### `src/cli.ts`
- **Location:** `src/cli.ts:3-15`
- **Change:** Extend the `Operator` union to include `%` and add a `case` in `calculate` that returns the modulo result.
- **Behavior:** `calculate(left, "%", right)` returns `left % right`.
- **Rationale:** Support modulo at the core calculation layer used by the CLI.

### `src/index.ts`
- **Location:** `src/index.ts:23-36`
- **Change:** Add `%` to the `choices` array for the `operator` positional argument.
- **Location:** `src/index.ts:35-37`
- **Change:** Extend the operator type assertion to include `%` so TypeScript aligns with the updated union.
- **Behavior:** CLI accepts `%` as a valid operator in `calc <left> <operator> <right>` and passes it through to `calculate`.

### `tests/unit.test.ts`
- **Location:** `tests/unit.test.ts:1-20`
- **Change:** Add a unit test verifying modulo output, e.g., `calculate(10, "%", 3)` returns `1`.
- **Behavior:** Ensures modulo is implemented in core logic.

### `tests/e2e.test.ts`
- **Location:** `tests/e2e.test.ts:29-38`
- **Change:** Add a CLI test for modulo, e.g., `runCli(["calc", "10", "%", "3"])` returns `stdout` of `"1"` with no stderr.
- **Behavior:** Ensures CLI parsing and output handling support `%` end-to-end.

## Constraints and assumptions
- **Assumption:** Modulo should follow JavaScript `%` semantics (remainder, not mathematical modulo) since no custom behavior is specified.
- **Constraint:** Keep operator handling limited to binary operations on numbers; no additional parsing or precedence changes are needed.

## Example target behavior
```ts
calculate(10, "%", 3) // => 1
```
```bash
bun run src/index.ts calc 10 % 3
# stdout: 1
```

## Dependencies
- No new dependencies required. Existing `yargs` usage remains unchanged.