### PR TITLE
fix: change hello output to hello world

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
Changed `src/cli.ts` to make the hello command print "Hello, World!" as the single source of truth, and updated `tests/e2e.test.ts` to match the new output.

Tests: `bun test tests/e2e.test.ts`

## Specification
# Specification: Change greeting to "Hello, World!"

## Context & findings
- The CLI prints `currentText` for the `hello` command, sourced from `src/cli.ts` and invoked in `src/index.ts` (`console.log(currentText);`). Evidence: `src/index.ts:1-27`, `src/cli.ts:1`.
- The end-to-end test asserts the exact output for `hello`. Evidence: `tests/e2e.test.ts:25-36`.
- No external library changes are required; existing CLI uses `yargs` v18.0.0. Evidence: `package.json:17-19`.

## Required changes by file

### `src/cli.ts:1`
- Change the exported `currentText` string value from `"Hello via Bun!"` to `"Hello, World!"`.
- This is the single source of truth for the `hello` output used by the CLI command.

### `tests/e2e.test.ts:31`
- Update the `hello prints the current text` assertion to expect `"Hello, World!"`.
- Keep other assertions unchanged.

## Assumptions
- The intended behavior is that running `bun run src/index.ts hello` prints exactly `Hello, World!` with no extra whitespace, consistent with the current `.trim()` in the test.

## Notes on dependencies
- No new dependencies or version updates are required for this change.