### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
- Added modulo operator support in CLI parsing and arithmetic dispatch so `%` is accepted and computed.
- Extended unit tests with a modulo case to cover the new operator behavior.

Tests: `bun test tests/unit.test.ts`

## Specification
# Specification: Add modulo operator support

## Context and research
- CLI calculator lives in `src/index.ts` and delegates arithmetic to `calculate` in `src/cli.ts`. The operator is constrained by yargs `choices` and by TypeScript union typing before calling `calculate` (`src/index.ts:15-38`).
- Core arithmetic dispatch is a `switch` on an `Operator` union in `calculate` (`src/cli.ts:3-15`).
- Tests cover the four arithmetic operations in `tests/unit.test.ts:4-19`.
- Dependencies: yargs is used for CLI parsing; no additional external libraries appear needed for modulo support.

## Assumptions
- Modulo should use JavaScript `%` (remainder) semantics for numbers; no special handling for negative operands or division-by-zero is requested.
- CLI should accept `%` as a valid operator alongside existing ones.

## Required changes by file

### `src/cli.ts`
- Extend the `Operator` union to include `%` so it can be passed from the CLI (`src/cli.ts:3`).
- Add a `%` branch in `calculate` that returns `left % right` (`src/cli.ts:5-15`).
- Ensure the function still returns a `number` for all valid operators.

Example target behavior:
```ts
calculate(10, "%", 3) // => 1
```

### `src/index.ts`
- Expand yargs operator `choices` to include `%` so the CLI accepts it (`src/index.ts:23-26`).
- Update the operator type assertion in the handler to include `%` (`src/index.ts:35`).

Example CLI usage:
```sh
bun run src/index.ts calc 10 % 3
# outputs: 1
```

### `tests/unit.test.ts`
- Add a unit test for modulo to verify `calculate` returns the expected remainder (`tests/unit.test.ts:4-19`).

Example test expectation:
```ts
expect(calculate(10, "%", 3)).toBe(1);
```

## External libraries
- None required. Existing usage of yargs remains unchanged beyond adding a `%` choice.