### PR TITLE
feat: add modulo operator support to calculator CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc with modulo prints correct result", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary

## What Changed

Added support for the modulo operator (`%`) to the calculator CLI, extending the existing four arithmetic operations.

### Files Modified

1. **src/cli.ts**
   - Added `"%"` to the `Operator` union type (line 3)
   - Added `case "%": return left % right;` to the switch statement in `calculate` function (lines 15-16)

2. **src/index.ts**
   - Added `"%"` to the yargs `choices` array (line 25)
   - Added `"%"` to the type assertion for operator (line 35)

3. **tests/unit.test.ts**
   - Added unit test for modulo: `expect(calculate(10, "%", 3)).toBe(1)` (lines 21-23)

4. **tests/e2e.test.ts**
   - Added E2E test for modulo CLI usage: verifies `calc 10 % 3` outputs `1` (lines 41-46)

## Why

The specification required adding the modulo operator to complete the set of arithmetic operations. All changes follow the existing patterns in the codebase.

## Validation

- All 8 tests pass (5 unit tests + 3 E2E tests)
- Changes committed and pushed to branch `o-agents/issue-4-20260125-124252_0094-2`

## Specification
# Change Specification: Support Modulo Operator

## Summary

Add support for the modulo operator (`%`) to the calculator CLI, extending the existing four arithmetic operations (`+`, `-`, `*`, `/`).

---

## Research Findings

### Architecture Overview

This is a TypeScript CLI calculator application using:
- **Runtime:** Bun
- **CLI Framework:** yargs v18.0.0
- **Testing:** Bun's built-in test framework (`bun:test`)

### Current Operator Implementation

The codebase follows a clean separation pattern:
- `src/cli.ts` - Core business logic (type definitions and `calculate` function)
- `src/index.ts` - CLI interface using yargs

Operators are defined in two locations:
1. **Type definition** in `src/cli.ts:3` - Literal union type `Operator`
2. **CLI validation** in `src/index.ts:25` - yargs `choices` array for positional argument

The `calculate` function uses an exhaustive switch-case pattern (`src/cli.ts:5-15`).

### Patterns and Conventions

- Operators are single-character strings
- Switch-case handles each operator explicitly (no default case due to exhaustive type checking)
- Type assertions used in CLI handler to narrow yargs parsed values
- Unit tests cover each operator with a single representative test case
- E2E tests verify CLI output format

---

## File Changes

### 1. `src/cli.ts`

**Location:** Line 3 (Operator type definition)

**Current:**
```typescript
export type Operator = "+" | "-" | "*" | "/";
```

**Required change:** Add `"%"` to the union type:
```typescript
export type Operator = "+" | "-" | "*" | "/" | "%";
```

---

**Location:** Lines 5-15 (calculate function switch statement)

**Current:**
```typescript
export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
  }
}
```

**Required change:** Add case for modulo operator:
```typescript
export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
    case "%":
      return left % right;
  }
}
```

---

### 2. `src/index.ts`

**Location:** Line 25 (yargs choices array)

**Current:**
```typescript
choices: ["+", "-", "*", "/"] as const,
```

**Required change:** Add `"%"` to the choices array:
```typescript
choices: ["+", "-", "*", "/", "%"] as const,
```

---

**Location:** Line 35 (type assertion in handler)

**Current:**
```typescript
const operator = argv.operator as "+" | "-" | "*" | "/";
```

**Required change:** Add `"%"` to the type assertion:
```typescript
const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
```

---

### 3. `tests/unit.test.ts`

**Location:** After line 19 (inside describe block)

**Required change:** Add a new test case for modulo:
```typescript
test("modulo", () => {
  expect(calculate(10, "%", 3)).toBe(1);
});
```

---

### 4. `tests/e2e.test.ts`

**Location:** After line 39 (inside describe block)

**Required change:** Add an E2E test for modulo CLI usage:
```typescript
test("calc with modulo prints correct result", async () => {
  const result = await runCli(["calc", "10", "%", "3"]);
  expect(result.exitCode).toBe(0);
  expect(result.stderr).toBe("");
  expect(result.stdout).toBe("1");
});
```

---

## Assumptions

1. **Standard JavaScript modulo behavior:** Uses `%` operator directly, which follows JavaScript semantics (remainder, not Euclidean modulo). For example, `-10 % 3` returns `-1`, not `2`.
2. **No division by zero handling:** Consistent with existing `/` operator implementation, which does not handle division by zero explicitly. Modulo by zero will return `NaN`.
3. **Test values:** Used `10 % 3 = 1` as the representative test case, matching the pattern of other tests using small positive integers.

---

## Dependencies

No external libraries required. The modulo operation uses JavaScript's native `%` operator.

---

## Evidence

| Change | File Location | Current Code |
|--------|---------------|--------------|
| Type definition | `src/cli.ts:3` | `export type Operator = "+" \| "-" \| "*" \| "/"` |
| Switch case | `src/cli.ts:6-14` | Four arithmetic cases |
| CLI choices | `src/index.ts:25` | `choices: ["+", "-", "*", "/"] as const` |
| Type assertion | `src/index.ts:35` | `as "+" \| "-" \| "*" \| "/"` |
| Unit tests | `tests/unit.test.ts:5-19` | Four test cases for each operator |
| E2E tests | `tests/e2e.test.ts:34-39` | Single calc E2E test |