### PR TITLE
fix: update hello output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
- Updated `currentText` to print "Hello, World!" for the `hello` command per spec (`src/cli.ts`).
- Adjusted the end-to-end test expectation to match the new output (`tests/e2e.test.ts`).

Tests not run (no test script specified).

## Specification
# Change Specification: print "Hello, World!"

## Scope
Update the CLI "hello" output and its test expectation to use "Hello, World!" instead of "Hello via Bun!".

## Research and context
- The CLI command `hello` prints `currentText` from `src/cli.ts` (`console.log(currentText);`). `currentText` is currently set to "Hello via Bun!". Evidence: `src/index.ts:3,11`, `src/cli.ts:1`.
- End-to-end tests assert the `hello` command output equals "Hello via Bun!". Evidence: `tests/e2e.test.ts:27-32`.
- CLI is built with `yargs` and Bun runtime; no external library changes are required for this text update. Evidence: `src/index.ts:1-5`, `package.json:15-17`.

## Required changes by file
- `src/cli.ts:1`
  - Change `currentText` to the exact string `"Hello, World!"`.
  - Ensure the `hello` command continues to print `currentText` without extra whitespace or punctuation changes.
  - Target behavior snippet:
    ```ts
    export const currentText = "Hello, World!";
    ```

- `tests/e2e.test.ts:27-32`
  - Update the expected stdout for the `hello` test to `"Hello, World!"`.
  - Target behavior snippet:
    ```ts
    expect(result.stdout).toBe("Hello, World!");
    ```

## Assumptions
- No other commands or outputs need changes; only the `hello` command output is in scope.
- Tests should continue to use `stdout.trim()` semantics from `runCli`, so the expected string should be exact without trailing whitespace.

## External libraries
- None required for this change. No new dependencies or version updates needed.