### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
- Added modulo operator support in CLI/operator typing and calculate switch to use JS remainder semantics.
- Extended unit and e2e coverage to validate modulo behavior through calculate and CLI.
- Tests: `bun test tests/unit.test.ts tests/e2e.test.ts`

## Specification
# Specification: Support modulo operator

## Context and research
- Architecture: simple Bun CLI with yargs; business logic is in `calculate` and exposed via a `calc <left> <operator> <right>` command.
  - CLI wiring and operator validation live in `src/index.ts:5-43`.
  - Arithmetic implementation and operator type are in `src/cli.ts:3-15`.
- Tests: unit tests cover `calculate` in `tests/unit.test.ts:1-19`; CLI e2e tests cover `calc` in `tests/e2e.test.ts:26-39`.
- Dependencies: `yargs` is used for CLI argument parsing (`package.json`, version `18.0.0`). No new external libraries are required.
- Constraints/patterns: operator choices are enforced via `choices` in yargs and a TypeScript union type; tests use Bun's `bun:test`.

Assumptions:
- Modulo should follow JavaScript `%` semantics (remainder, not mathematical modulo). This matches the project's current use of JS operators in `calculate`.

## Required changes by file

### `src/cli.ts`
- **Location:** `src/cli.ts:3-14`
- **Change:** Extend the `Operator` union to include `%` and handle `%` in `calculate` using the JavaScript remainder operator.
- **Target behavior snippet:**
  ```ts
  export type Operator = "+" | "-" | "*" | "/" | "%";

  export function calculate(left: number, operator: Operator, right: number): number {
    switch (operator) {
      case "%":
        return left % right;
      // existing cases
    }
  }
  ```

### `src/index.ts`
- **Location:** `src/index.ts:23-36`
- **Change:** Allow `%` in CLI operator choices and the operator type assertion so the CLI accepts modulo.
- **Target behavior snippet:**
  ```ts
  .positional("operator", {
    type: "string",
    choices: ["+", "-", "*", "/", "%"] as const,
    demandOption: true,
  })

  const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
  ```

### `tests/unit.test.ts`
- **Location:** `tests/unit.test.ts:4-19`
- **Change:** Add a unit test that verifies modulo behavior via `calculate`.
- **Target behavior snippet:**
  ```ts
  test("modulo", () => {
    expect(calculate(10, "%", 3)).toBe(1);
  });
  ```

### `tests/e2e.test.ts`
- **Location:** `tests/e2e.test.ts:26-39`
- **Change:** Add an e2e test ensuring the CLI accepts `%` and prints the correct result.
- **Target behavior snippet:**
  ```ts
  test("calc supports modulo", async () => {
    const result = await runCli(["calc", "10", "%", "3"]);
    expect(result.exitCode).toBe(0);
    expect(result.stderr).toBe("");
    expect(result.stdout).toBe("1");
  });
  ```

## Notes
- No new libraries are needed; the existing `yargs` CLI constraint list and TypeScript operator union should be extended.
- If the project wants mathematical modulo for negative numbers, clarify the rule; current JS remainder (`%`) is consistent with existing arithmetic operators.