### PR TITLE
fix: change hello command output to "Hello, World!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
# Change Summary

## What Changed

### `src/cli.ts`
- Changed the `currentText` constant value from `"Hello via Bun!"` to `"Hello, World!"`.

### `tests/e2e.test.ts`
- Updated the expected output assertion in the `hello` command test from `"Hello via Bun!"` to `"Hello, World!"`.

## Why

The specification required changing the CLI `hello` command output from "Hello via Bun!" to "Hello, World!". Both the source code and corresponding test were updated to reflect this change.

## Validation

- All e2e tests pass (2 tests, 6 assertions).
- Changes committed with message: `fix: change hello command output to "Hello, World!"`
- Branch pushed to origin.

## Specification
# Change Specification: Print "Hello, World!" instead of "Hello via Bun!"

## Summary

Change the CLI `hello` command output from "Hello via Bun!" to "Hello, World!".

## Research Findings

### Architecture

- The project is a CLI tool built with Bun and yargs.
- The `hello` command prints a constant string exported from `src/cli.ts`.
- The constant `currentText` is imported in `src/index.ts` and printed via `console.log()` when the `hello` command is invoked.

### File Structure

```
src/
├── cli.ts      # Exports currentText constant and calculate function
└── index.ts    # CLI entry point using yargs, imports currentText
tests/
└── e2e.test.ts # E2E tests for CLI commands
```

### Dependencies

- No external library changes required.

## Required Changes

### File: `src/cli.ts`

**Location:** Line 1

**Current:**
```typescript
export const currentText = "Hello via Bun!";
```

**Required:**
```typescript
export const currentText = "Hello, World!";
```

**Evidence:** `src/cli.ts:1`

---

### File: `tests/e2e.test.ts`

**Location:** Line 31

**Current:**
```typescript
expect(result.stdout).toBe("Hello via Bun!");
```

**Required:**
```typescript
expect(result.stdout).toBe("Hello, World!");
```

**Evidence:** `tests/e2e.test.ts:31`

## Assumptions

- The variable name `currentText` should remain unchanged since the issue only requests changing the output string, not renaming the variable.