### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
- Added modulo support to calculator core and CLI operator validation to accept `%`.
- Extended unit and e2e tests to cover modulo behavior and CLI usage.
- Tests: `bun test tests/unit.test.ts tests/e2e.test.ts`.

## Specification
# Specification: Support Modulo Operator

## Research findings
- CLI uses `yargs` to define commands and restrict operator choices to `+`, `-`, `*`, `/` (see `src/index.ts:15-37`).
- Calculator logic lives in `calculate`, which switches over a narrow `Operator` union type (see `src/cli.ts:3-15`).
- Unit tests cover the four arithmetic operators; e2e test only covers `+` through CLI (see `tests/unit.test.ts:4-19`, `tests/e2e.test.ts:26-39`).
- No external libraries are required for modulo support; native `%` operator is sufficient.

## Assumptions
- Modulo should follow JavaScript `%` semantics for numbers (same behavior as other operators already exposed).
- CLI should accept `%` as a valid operator alongside existing ones.

## Required changes by file

### `src/cli.ts`
- Extend the `Operator` union to include `%` so modulo is a first-class operator (`src/cli.ts:3`).
- Add a switch case in `calculate` that returns `left % right` when operator is `%` (`src/cli.ts:5-14`).

### `src/index.ts`
- Allow `%` in the `choices` array for the `operator` positional argument so CLI validation accepts modulo (`src/index.ts:23-27`).
- Expand the local type assertion for `operator` to include `%` to keep type safety consistent with `Operator` (`src/index.ts:35`).

### `tests/unit.test.ts`
- Add a unit test that asserts modulo works, e.g., `calculate(10, "%", 3) === 1` (`tests/unit.test.ts:4-19`).

### `tests/e2e.test.ts`
- Add a CLI test that exercises modulo via `calc`, e.g., `bun run ... calc 10 % 3` returns `1` with exit code 0 and empty stderr (`tests/e2e.test.ts:26-39`).

## Example target behavior
```ts
calculate(10, "%", 3) === 1
```

```bash
bun run src/index.ts calc 10 % 3
# stdout: 1
```