### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc with modulo prints correct result", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("computes modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary

## What Changed

Added support for the modulo operator (`%`) to the calculator CLI application.

### Files Modified

1. **src/cli.ts**
   - Extended `Operator` type union to include `"%"`
   - Added `case "%"` to the switch statement in `calculate()` function

2. **src/index.ts**
   - Added `"%"` to the yargs choices array for operator validation
   - Updated the type assertion to include `"%"`

3. **tests/unit.test.ts**
   - Added unit test: `"computes modulo"` testing `10 % 3 = 1`

4. **tests/e2e.test.ts**
   - Added e2e test: `"calc with modulo prints correct result"` testing CLI invocation

## Why

The specification required adding modulo operator support to enable users to compute the remainder of integer division alongside existing arithmetic operations (+, -, *, /).

## Verification

All 8 tests pass (14 expect() calls across 2 test files).

## Specification
# Change Specification: Support Modulo Operator

## Summary

Add support for the modulo operator (`%`) to the calculator CLI application, enabling users to compute the remainder of integer division alongside the existing four arithmetic operations.

## Research Findings

### Architecture Overview

This is a CLI calculator application using:
- **Runtime:** Bun
- **CLI Framework:** yargs 18.0.0
- **Testing:** bun:test (built-in)

The codebase follows high cohesion with:
- `src/cli.ts` - Core logic (Operator type + calculate function)
- `src/index.ts` - CLI entry point with yargs command definitions
- `tests/unit.test.ts` - Unit tests for the calculate function
- `tests/e2e.test.ts` - End-to-end CLI tests

### Current Implementation Pattern

Operators are:
1. Defined as a TypeScript union type (`src/cli.ts:3`)
2. Handled via switch statement in calculate function (`src/cli.ts:6-15`)
3. Validated by yargs choices constraint (`src/index.ts:25`)
4. Type-asserted in the command handler (`src/index.ts:35`)

### Constraints

- The modulo operator in JavaScript/TypeScript uses `%` syntax
- TypeScript's exhaustive switch pattern requires all union members to have a case

---

## Changes by File

### 1. `src/cli.ts`

**Location:** Line 3
**Change:** Extend the `Operator` type union to include `"%"`

```typescript
export type Operator = "+" | "-" | "*" | "/" | "%";
```

**Location:** Lines 13-14 (after the division case, before closing brace)
**Change:** Add modulo case to the switch statement

```typescript
    case "%":
      return left % right;
```

**Target state of calculate function:**
```typescript
export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
    case "%":
      return left % right;
  }
}
```

---

### 2. `src/index.ts`

**Location:** Line 25
**Change:** Add `"%"` to the choices array

```typescript
choices: ["+", "-", "*", "/", "%"] as const,
```

**Location:** Line 35
**Change:** Update the type assertion to include `"%"`

```typescript
const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
```

---

### 3. `tests/unit.test.ts`

**Location:** After line 19 (inside the describe block)
**Change:** Add unit test for modulo operation

```typescript
  test("computes modulo", () => {
    expect(calculate(10, "%", 3)).toBe(1);
  });
```

---

### 4. `tests/e2e.test.ts`

**Location:** After line 39 (inside the describe block)
**Change:** Add e2e test for modulo via CLI

```typescript
  test("calc with modulo prints correct result", async () => {
    const result = await runCli(["calc", "10", "%", "3"]);
    expect(result.exitCode).toBe(0);
    expect(result.stderr).toBe("");
    expect(result.stdout).toBe("1");
  });
```

---

## Assumptions

1. **Operator symbol:** Using `%` as the operator symbol since it is the standard modulo operator in JavaScript/TypeScript and consistent with mathematical convention.
2. **Behavior:** Using JavaScript's native `%` operator which returns the remainder with the sign of the dividend (e.g., `-10 % 3 === -1`).
3. **No special handling for division by zero:** Following the existing pattern where division by zero is not specially handled (returns `Infinity` or `NaN`), modulo by zero will return `NaN` per JavaScript behavior.
4. **Test values:** Using `10 % 3 = 1` as a clear, non-trivial test case.

---

## Dependencies

No new external libraries required. The implementation uses only built-in JavaScript operators.