### PR TITLE
feat: add modulo operator support to calculator CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc modulo prints only the number result", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary: Support Modulo Operator

## Changes Made

### 1. `src/cli.ts`
- **Line 3**: Added `"%"` to the `Operator` type union
- **Lines 14-15**: Added a new case for the modulo operator in the `calculate` function switch statement

### 2. `src/index.ts`
- **Line 25**: Added `"%"` to the yargs `choices` array for operator validation
- **Line 35**: Added `"%"` to the type assertion for the operator variable

### 3. `tests/unit.test.ts`
- **After line 19**: Added unit test `"modulos"` that verifies `calculate(10, "%", 3)` returns `1`

### 4. `tests/e2e.test.ts`
- **After line 39**: Added E2E test `"calc modulo prints only the number result"` that verifies the CLI correctly handles `calc 10 % 3` and outputs `1`

## Why
These changes implement the modulo operator (`%`) as a fifth arithmetic operation in the calculator CLI, enabling users to compute remainders via both the programmatic API and CLI interface.

## Verification
- All 8 tests pass (6 existing + 2 new modulo tests)
- Changes committed with conventional commit prefix: `feat: add modulo operator support to calculator CLI`
- Branch pushed to origin

## Specification
# Change Specification: Support Modulo Operator

## Summary

Add support for the modulo operator (`%`) to the existing calculator CLI, which currently supports four arithmetic operations (`+`, `-`, `*`, `/`).

---

## Research Findings

### Architecture

The calculator application follows a simple two-layer architecture:

1. **Business Logic Layer** (`src/cli.ts`): Contains the `calculate()` function and `Operator` type
2. **CLI Layer** (`src/index.ts`): Handles command-line argument parsing with yargs and invokes the calculate function

### Dependencies

- **Runtime**: Bun
- **CLI Framework**: yargs (no changes required to package dependencies)

### Patterns

- Operators are defined as a TypeScript union type for type safety
- The `calculate()` function uses a switch statement to handle each operator
- yargs `choices` array validates allowed operators at the CLI layer
- Each operator has dedicated unit tests and follows consistent test naming

### Constraints

- The modulo operator in JavaScript/TypeScript (`%`) returns the remainder of integer division
- For floating-point numbers, JavaScript's `%` operator returns the floating-point remainder (e.g., `5.5 % 2` returns `1.5`)

---

## Changes by File

### 1. `src/cli.ts`

**Location**: Line 3 (type definition)

**Current**:
```typescript
export type Operator = "+" | "-" | "*" | "/";
```

**Required Change**: Add `"%"` to the union type:
```typescript
export type Operator = "+" | "-" | "*" | "/" | "%";
```

---

**Location**: Lines 5-15 (calculate function)

**Current**:
```typescript
export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
  }
}
```

**Required Change**: Add a case for the modulo operator:
```typescript
export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
    case "%":
      return left % right;
  }
}
```

---

### 2. `src/index.ts`

**Location**: Line 25 (choices array)

**Current**:
```typescript
choices: ["+", "-", "*", "/"] as const,
```

**Required Change**: Add `"%"` to the choices array:
```typescript
choices: ["+", "-", "*", "/", "%"] as const,
```

---

**Location**: Line 35 (type assertion)

**Current**:
```typescript
const operator = argv.operator as "+" | "-" | "*" | "/";
```

**Required Change**: Add `"%"` to the type assertion:
```typescript
const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
```

---

### 3. `tests/unit.test.ts`

**Location**: After line 19 (add new test case)

**Required Change**: Add a test case for the modulo operator following the existing test naming pattern:
```typescript
test("modulos", () => {
  expect(calculate(10, "%", 3)).toBe(1);
});
```

---

### 4. `tests/e2e.test.ts`

**Location**: After line 39 (add new test case)

**Required Change**: Add an E2E test for the modulo operator via CLI:
```typescript
test("calc modulo prints only the number result", async () => {
  const result = await runCli(["calc", "10", "%", "3"]);
  expect(result.exitCode).toBe(0);
  expect(result.stderr).toBe("");
  expect(result.stdout).toBe("1");
});
```

---

## Assumptions

1. The modulo operator should use the `%` symbol, which is the standard JavaScript/TypeScript operator for remainder
2. No special handling is needed for division by zero (consistent with the existing `/` operator behavior)
3. The test naming convention "modulos" follows the existing pattern ("adds", "subtracts", "multiplies", "divides")

---

## File Reference Summary

| File | Lines to Modify |
|------|-----------------|
| `src/cli.ts` | 3, 14-15 (add case) |
| `src/index.ts` | 25, 35 |
| `tests/unit.test.ts` | 19 (add after) |
| `tests/e2e.test.ts` | 39 (add after) |