### PR TITLE
feat: add modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
## Summary
- Added `%` support to the core `calculate()` helper by extending `Operator` and implementing the remainder branch.
- Updated the `calc` CLI command to accept `%` via yargs `choices` and removed the duplicated operator union by reusing the exported `Operator` type.
- Added unit + e2e coverage to ensure modulo works end-to-end and that the CLI prints only the numeric result.

## Specification
# Change Specification: Support modulo (`%`) operator

## Goal
Extend the existing `calc` CLI command and the `calculate()` helper to support the modulo operator (`%`) in addition to `+`, `-`, `*`, `/`.

## Current behavior (evidence)
- CLI only accepts operators `+ - * /` via yargs positional `choices` and a hard-coded union type in the handler (`src/index.ts:23-37`).
- Core arithmetic dispatch is implemented in `calculate()` with `Operator` as a `"+" | "-" | "*" | "/"` union (`src/cli.ts:3-15`).
- Tests cover only the four operators (unit: `tests/unit.test.ts:4-19`, e2e: `tests/e2e.test.ts:26-39`).

## Semantics / assumptions
- `%` should use JavaScript/TypeScript’s remainder operator semantics: `left % right`.
  - This supports non-integers as JS does (e.g., `5.5 % 2 === 1.5`).
  - Modulo by zero should follow JS semantics (`x % 0` yields `NaN`); no extra validation is required unless the project already validates division by zero (it currently does not).

## Required changes (by file)

### `src/cli.ts`
- **Expand** `Operator` to include `"%"` (`src/cli.ts:3`).
- **Add** a `%` branch to `calculate()` returning `left % right` (`src/cli.ts:5-15`).

Target behavior:
```ts
export type Operator = "+" | "-" | "*" | "/" | "%";

// inside switch
case "%":
  return left % right;
```

### `src/index.ts`
- **Allow** `%` as an accepted CLI operator by adding it to the yargs `choices` list (`src/index.ts:23-27`).
- **Avoid divergence** between CLI typing and `Operator` by using the exported type instead of duplicating a literal union.
  - Replace `const operator = argv.operator as "+" | "-" | "*" | "/";` with `const operator = argv.operator as Operator;` and import `type Operator` from `./cli`.

Target behavior:
```ts
import { calculate, currentText, type Operator } from "./cli";

// ...
choices: ["+", "-", "*", "/", "%"] as const,

const operator = argv.operator as Operator;
```

### `tests/unit.test.ts`
- **Add** a unit test for modulo (`tests/unit.test.ts:4-19`).

Target behavior:
```ts
test("modulo", () => {
  expect(calculate(10, "%", 4)).toBe(2);
});
```

### `tests/e2e.test.ts`
- **Add** an e2e test ensuring the CLI accepts `%` and prints only the numeric result (`tests/e2e.test.ts:26-39`).

Target behavior:
```ts
test("calc supports modulo", async () => {
  const result = await runCli(["calc", "10", "%", "4"]);
  expect(result.exitCode).toBe(0);
  expect(result.stderr).toBe("");
  expect(result.stdout).toBe("2");
});
```

## Architecture / dependencies notes
- This project is a small Bun + TypeScript CLI with yargs routing (`src/index.ts:1-43`) and a single arithmetic helper (`src/cli.ts:1-16`).
- Testing uses `bun:test` (see `tests/unit.test.ts:1-20`, `tests/e2e.test.ts:1-40`).
- No new external libraries are required for `%` support. Existing relevant dependencies: `yargs@18.0.0` (`package.json`).