### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Closes #1

## Summary
## Change Summary
- Updated `src/cli.ts` to export `currentText = "Hello, World!"` so the `hello` CLI command prints the required message.
- Updated `tests/e2e.test.ts` to assert trimmed stdout equals `"Hello, World!"`, keeping the existing `trim()` normalization.

## Specification
# Change Specification: Print "Hello, World!"

## Goal
Running the CLI command `hello` prints `Hello, World!` to stdout (as observed after `trim()` in the e2e test), not `Hello via Bun!`.

## Current Behavior (evidence)
- `src/cli.ts:1` defines `currentText = "Hello via Bun!"`.
- `src/index.ts:5` wires up the CLI; the `hello` command prints `currentText` via `console.log(currentText)` (`src/index.ts:11`).
- `tests/e2e.test.ts:31` asserts stdout equals `"Hello via Bun!"`.

## Required Changes

### `src/cli.ts`
- Change the exported `currentText` constant value from `"Hello via Bun!"` to exactly `"Hello, World!"` (`src/cli.ts:1`).
- Keep the symbol name/export unchanged so `src/index.ts` continues to import it (`src/index.ts:3`).

### `tests/e2e.test.ts`
- Update the `hello prints the current text` expectation to assert stdout equals `"Hello, World!"` (`tests/e2e.test.ts:27`, `tests/e2e.test.ts:31`).
- Keep the existing trimming behavior in `runCli` (`tests/e2e.test.ts:20`) so the assertion continues to compare normalized output.

## Out of Scope / Non-Changes
- Do not change `calculate` or the `calc` command behavior (`src/cli.ts:5`, `src/index.ts:15`; validated by `tests/e2e.test.ts:34` and `tests/unit.test.ts:4`).

## Architecture, Dependencies, Constraints
- TypeScript ESM project (`package.json:9`) with entry at `src/index.ts` (`package.json:10`).
- CLI uses `yargs` (`src/index.ts:1`) with dependency pinned to `yargs@18.0.0` (`package.json:16-18`).
- Tests use Bun’s test runner (`tests/e2e.test.ts:1`) and execute the CLI via `Bun.spawn(["bun", "run", entry, ...])` (`tests/e2e.test.ts:8`).