### PR TITLE
feat: support modulo operator in calculator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc modulo prints only the number result", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary

## What changed

Added the `%` (modulo) operator to the arithmetic calculator across four files:

### `src/cli.ts`
- Added `"%"` to the `Operator` type union.
- Added `case "%": return left % right;` to the `switch` block in `calculate()`.

### `src/index.ts`
- Imported `type Operator` from `./cli` to avoid duplicating the type.
- Added `"%"` to the yargs `choices` array.
- Changed the type cast from a literal union (`as "+" | "-" | "*" | "/"`) to `as Operator`.

### `tests/unit.test.ts`
- Added a `"modulos"` unit test: `calculate(10, "%", 3)` expects `1`.

### `tests/e2e.test.ts`
- Added a `"calc modulo prints only the number result"` E2E test: runs `calc 10 % 3` and expects stdout `"1"`.

## Why

The specification required adding modulo as a fifth arithmetic operator, following all existing patterns and conventions. The `Operator` type import in `src/index.ts` eliminates duplication between the type definition and the cast.

## Verification

All 8 tests pass (5 unit + 3 E2E), including the 2 new modulo tests.

## Specification
# Specification: Support Modulo Operator

## Summary

Add the `%` (modulo) operator to the arithmetic calculator alongside the existing four arithmetic operations (`+`, `-`, `*`, `/`). This requires changes in three files: the core logic module, the CLI entry point, and the test files.

---

## Research Findings

### Architecture

The calculator is a CLI application built with Bun and yargs v18.0.0. The data flow is:

```
CLI args → yargs parser (src/index.ts) → calculate() (src/cli.ts) → stdout
```

- **`src/cli.ts`**: Defines the `Operator` type union and the `calculate` function with a `switch` statement over operator cases.
- **`src/index.ts`**: Configures yargs with a `calc` command, constraining the `operator` positional argument via a `choices` array.
- **`tests/unit.test.ts`**: Unit tests for `calculate()` using `bun:test`.
- **`tests/e2e.test.ts`**: End-to-end tests that spawn the CLI as a subprocess.

### Patterns & Conventions

- Each operator is a single-character string literal in the `Operator` type union (`src/cli.ts:3`).
- Each operator has a corresponding `case` in the `switch` block (`src/cli.ts:6-14`).
- The yargs `choices` array mirrors the `Operator` type union exactly (`src/index.ts:25`).
- The handler casts `argv.operator` to the `Operator` type union (`src/index.ts:35`).
- Each operator has one unit test (`tests/unit.test.ts:5-19`) and there is one E2E test for the overall calc command (`tests/e2e.test.ts:34-39`).
- JavaScript's `%` operator returns the remainder with the sign of the dividend (e.g., `-7 % 3 === -1`), consistent with standard modulo behavior in most languages.

### Dependencies

- No new dependencies are required. The `%` operator is native to JavaScript/TypeScript.

---

## Changes by File

### 1. `src/cli.ts`

**Location: line 3 — `Operator` type**

Add `"%"` to the union type.

```typescript
export type Operator = "+" | "-" | "*" | "/" | "%";
```

**Location: lines 13-14 — `switch` block, before the closing `}`**

Add a `case "%"` branch that returns `left % right`.

```typescript
    case "%":
      return left % right;
```

The resulting `calculate` function should be:

```typescript
export function calculate(left: number, operator: Operator, right: number): number {
  switch (operator) {
    case "+":
      return left + right;
    case "-":
      return left - right;
    case "*":
      return left * right;
    case "/":
      return left / right;
    case "%":
      return left % right;
  }
}
```

---

### 2. `src/index.ts`

**Location: line 25 — `choices` array**

Add `"%"` to the choices array.

```typescript
          choices: ["+", "-", "*", "/", "%"] as const,
```

**Location: line 35 — type cast for `operator`**

Update the type assertion to include `"%"`.

```typescript
      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
```

Alternatively, this cast can reference the `Operator` type directly (which would be cleaner and avoid duplication):

```typescript
import { calculate, currentText, type Operator } from "./cli";
// ...
      const operator = argv.operator as Operator;
```

---

### 3. `tests/unit.test.ts`

**Location: after line 19 — new test case**

Add a unit test for modulo inside the `describe("calculate", ...)` block, following the existing pattern.

```typescript
  test("modulos", () => {
    expect(calculate(10, "%", 3)).toBe(1);
  });
```

---

### 4. `tests/e2e.test.ts`

**Location: after line 39 — new test case**

Add an E2E test for the modulo operator inside the `describe("cli", ...)` block, following the existing pattern.

```typescript
  test("calc modulo prints only the number result", async () => {
    const result = await runCli(["calc", "10", "%", "3"]);
    expect(result.exitCode).toBe(0);
    expect(result.stderr).toBe("");
    expect(result.stdout).toBe("1");
  });
```

---

## Assumptions

- The `%` character is used as the modulo operator symbol, consistent with JavaScript/TypeScript convention.
- No special handling for modulo by zero is required, matching the existing behavior where division by zero is not handled (JavaScript returns `NaN` for `0 % 0` and `Infinity`-related edge cases, but returns a valid number for `n % 0` → `NaN`). This is consistent with how `/` is already handled.
- The test values use simple positive integers to match the style of existing tests.