### PR TITLE
feat: add modulo operator to calc

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,11 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
+    default: {
+      const _exhaustive: never = operator;
+      return _exhaustive;
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "5", "%", "2"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,12 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulos", () => {
+    expect(calculate(5, "%", 2)).toBe(1);
+  });
+
+  test("modulos with negative dividend (JS remainder semantics)", () => {
+    expect(calculate(-5, "%", 2)).toBe(-1);
+  });
 });


### PR DESCRIPTION
Closes #4

## Summary
# Change Summary

- Added `%` support to the `calc <left> <operator> <right>` command using JavaScript remainder semantics (`left % right`).
- Removed operator-type duplication in the CLI by importing and using the shared `Operator` type from `src/cli.ts`.
- Extended unit tests to cover modulo (including negative dividend behavior to lock in JS remainder semantics).
- Added an E2E test verifying the CLI accepts `%` and prints only the numeric result.

Why:
- The CLI previously only supported `+`, `-`, `*`, `/`. This change adds `%` with correct JS behavior and ensures both unit + E2E coverage.

## Specification
# Spec: Support modulo (`%`) operator

## Summary
Add support for the modulo operator (`%`) to the existing `calc <left> <operator> <right>` CLI command, alongside `+`, `-`, `*`, `/`. The implementation should follow JavaScript’s `%` remainder semantics.

## Current Behavior / Architecture
- The CLI is a Bun + TypeScript app using `yargs`.
- `src/index.ts` defines two commands: `hello` and `calc <left> <operator> <right>` (binary operator only; no expression parsing/precedence). `calc` constrains the operator via a `choices` list and then calls `calculate(...)`. (`src/index.ts:14-39`)
- `src/cli.ts` exports `Operator` as a string-literal union and `calculate(left, operator, right)` as a `switch` dispatch over the operator. (`src/cli.ts:3-16`)
- Tests:
  - Unit tests cover the 4 existing operators via `calculate(...)`. (`tests/unit.test.ts:4-20`)
  - E2E tests run the CLI and assert output. (`tests/e2e.test.ts:7-40`)

Dependencies noted:
- `yargs` is pinned to `18.0.0` (`package.json:17-19`). No new external libraries are required for this feature.

## Target Behavior
### Operator support
- Accept `%` as a valid `<operator>` value for the `calc` command.
- When `<operator>` is `%`, compute and print `left % right`.

### Semantics (important)
- Use JavaScript remainder semantics for `%` since operands are `number` and this is a JS runtime.
  - Example: `5 % 2 === 1`
  - Example: `-5 % 2 === -1` (remainder keeps the dividend’s sign)
  - Example: `5 % 0` yields `NaN`
- Reference: MDN “Remainder (%)” operator docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder

## Required Code Changes (by file)

### `src/cli.ts`
**Locations:** `src/cli.ts:3-16`
- Extend the `Operator` union to include `%`.
  - From: `"+" | "-" | "*" | "/"` (`src/cli.ts:3`)
  - To: add `"%"`
- Add a `case "%":` branch in `calculate(...)` returning `left % right`.
- Ensure the `switch` remains exhaustive for `Operator` so TypeScript control-flow analysis continues to guarantee a `number` return.

### `src/index.ts`
**Locations:** `src/index.ts:14-39`
- Update the `yargs` positional definition for `operator` to allow `%`.
  - Add `%` to `choices: ["+", "-", "*", "/"] as const` (`src/index.ts:23-27`).
- Update the operator type assertion to include `%`.
  - Current: `const operator = argv.operator as "+" | "-" | "*" | "/";` (`src/index.ts:35`)
  - Target: include `%`, or (preferred to reduce duplication) import and use `Operator` from `src/cli.ts`:
    - `import { calculate, currentText, type Operator } from "./cli";`
    - `const operator = argv.operator as Operator;`

### `tests/unit.test.ts`
**Locations:** `tests/unit.test.ts:4-20`
- Add a unit test asserting modulo works, e.g.:
  - `expect(calculate(5, "%", 2)).toBe(1);`
- (Recommended) Add a test documenting negative behavior to lock in JS remainder semantics, e.g.:
  - `expect(calculate(-5, "%", 2)).toBe(-1);`

### `tests/e2e.test.ts`
**Locations:** `tests/e2e.test.ts:26-40`
- Add an E2E test verifying the CLI accepts `%` and prints only the numeric result, e.g.:
  - `runCli(["calc", "5", "%", "2"])` returns `stdout === "1"`, `stderr === ""`, `exitCode === 0`.

### (Optional) `README.md`
**Locations:** `README.md:1-15`
- Add a brief `calc` usage example including `%` (purely documentation; not required by the issue).

## Acceptance Criteria
- `bun test` passes and includes coverage for `%` in both unit and E2E suites.
- `bun run src/index.ts calc 5 % 2` prints `1` with no extra output.
- Invalid operators still fail under `yargs` strict mode (unchanged behavior), with `%` now considered valid.