### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate, currentText } from "../src/cli";
+
+describe("currentText", () => {
+  test("should be 'Hello, World!'", () => {
+    expect(currentText).toBe("Hello, World!");
+  });
+});
 
 describe("calculate", () => {
   test("adds", () => {


### PR DESCRIPTION
## Summary
- Update `currentText` in `src/cli.ts` from `"Hello via Bun!"` to `"Hello, World!"`
- Update the e2e test expectation to match the new greeting

Closes #1

## Test plan
- [x] `bun test` passes (7/7 tests, 0 failures)
- [x] Unit test asserts `currentText === "Hello, World!"`
- [x] E2E test asserts CLI `hello` command outputs `"Hello, World!"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)