### PR TITLE
fix: print Hello, World! from hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -17,8 +17,8 @@ async function runCli(args: string[]) {
   ]);
 
   return {
-    stdout: stdout.trim(),
-    stderr: stderr.trim(),
+    stdout,
+    stderr,
     exitCode,
   };
 }
@@ -28,13 +28,13 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello, World!");
+    expect(result.stdout).toBe("Hello, World!\n");
   });
 
   test("calc prints only the number result", async () => {
     const result = await runCli(["calc", "2", "+", "3"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("5");
+    expect(result.stdout).toBe("5\n");
   });
 });

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -4,8 +4,8 @@ import { dirname, join } from "path";
 
 const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
 
-async function runCli(args: string[]) {
-  const proc = Bun.spawn(["bun", "run", entry, ...args], {
+async function runCli(command: string[]) {
+  const proc = Bun.spawn(command, {
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -25,14 +25,21 @@ async function runCli(args: string[]) {
 
 describe("cli", () => {
   test("hello prints Hello, World!", async () => {
-    const result = await runCli(["hello"]);
+    const result = await runCli(["bun", "run", entry, "hello"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("Hello, World!\n");
+  });
+
+  test("package entrypoint hello prints Hello, World!", async () => {
+    const result = await runCli(["bun", "run", ".", "hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("Hello, World!\n");
   });
 
   test("calc prints only the number result", async () => {
-    const result = await runCli(["calc", "2", "+", "3"]);
+    const result = await runCli(["bun", "run", entry, "calc", "2", "+", "3"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5\n");

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #4

## Customer Summary

- The `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- Users running the command through either the source entrypoint or the package entrypoint see the same updated message.
- No migration or rollout steps are required.

## Technical Summary

- Updated `currentText` in `src/cli.ts` to the new hello message.
- Adjusted E2E tests to assert raw stdout, including the trailing newline emitted by `console.log`.
- Added E2E coverage for running `hello` through the package entrypoint with `bun run . hello`.

## Why

- Issue #4 requests changing the visible hello output to `Hello, World!`.
- Updating the shared `currentText` constant keeps both CLI entrypoints consistent without duplicating message logic.

## Testing

- `PATH=/Users/exkazuu/.local/share/mise/installs/bun/latest/bin:$PATH /Users/exkazuu/.local/share/mise/installs/bun/latest/bin/bun test`
