### PR TITLE
fix: print Hello, World from hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -4,8 +4,8 @@ import { dirname, join } from "path";
 
 const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
 
-async function runCli(args: string[]) {
-  const proc = Bun.spawn(["bun", "run", entry, ...args], {
+async function runCli(command: string[]) {
+  const proc = Bun.spawn(command, {
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -17,24 +17,31 @@ async function runCli(args: string[]) {
   ]);
 
   return {
-    stdout: stdout.trim(),
-    stderr: stderr.trim(),
+    stdout,
+    stderr,
     exitCode,
   };
 }
 
 describe("cli", () => {
   test("hello prints Hello, World!", async () => {
-    const result = await runCli(["hello"]);
+    const result = await runCli(["bun", "run", entry, "hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello, World!");
+    expect(result.stdout).toBe("Hello, World!\n");
+  });
+
+  test("package entrypoint hello prints Hello, World!", async () => {
+    const result = await runCli(["bun", "run", ".", "hello"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("Hello, World!\n");
   });
 
   test("calc prints only the number result", async () => {
-    const result = await runCli(["calc", "2", "+", "3"]);
+    const result = await runCli(["bun", "run", entry, "calc", "2", "+", "3"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("5");
+    expect(result.stdout).toBe("5\n");
   });
 });

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #4

Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!`.
- Users running either the source entrypoint or package entrypoint see the same corrected greeting.
- No migration or compatibility steps are required.

## Technical Summary

- Updated the CLI greeting text exported from `src/cli.ts`.
- The PR also includes e2e coverage for `bun run src/index.ts hello` and `bun run . hello` expecting the corrected output.
- The calculator command behavior is unchanged.

## Why

- The CLI previously printed `Hello via Bun!`, which did not match the requested behavior.
- Keeping the greeting value centralized preserves the existing command structure while fixing the visible output.

## Testing

- `bun test tests/e2e.test.ts`
