### PR TITLE
fix: print Hello, World greeting

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!`.
- Users no longer see the old `Hello via Bun!` message when running the greeting command.
- No migration or compatibility action is needed.

## Technical Summary

- Updated the production `currentText` value used by the `hello` command.
- The E2E test on this branch verifies the real CLI exits successfully, writes nothing to stderr, and prints the new greeting.
- No dependencies or configuration changed.

## Why

- The issue requested changing the user-visible greeting text.
- Updating the shared greeting constant keeps the CLI behavior aligned with the existing command flow and test coverage.

## Testing

- `bun test`
