### PR TITLE
fix: print "Hello, World!" from hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints "Hello, World!" instead of "Hello via Bun!".
- No configuration or workflow changes are needed; users see the new greeting immediately after upgrading.

## Technical Summary

- Updated `currentText` in `src/cli.ts` to `"Hello, World!"`.
- Adjusted the e2e expectation in `tests/e2e.test.ts` to match the new output.

## Why

- The previous greeting leaked the runtime ("Bun") into user-visible output. The issue requested the canonical "Hello, World!" string.
- Changing the single exported constant is the minimal change that satisfies the spec without touching CLI plumbing.

## Testing

- `bun test` — all 6 tests pass, including the e2e case that spawns `bun run src/index.ts hello` and asserts stdout equals "Hello, World!".

## Notes

- None.
