### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!`.
- Users no longer see the old `Hello via Bun!` message.
- No migration or compatibility steps are required.

## Technical Summary

- Updated the exported CLI text constant in `src/cli.ts`.
- The e2e CLI test now verifies the real `hello` command exits successfully, writes no stderr, and emits exactly `Hello, World!`.
- The change is intentionally limited to the hello output behavior.

## Why

- The issue requires the CLI greeting to match `Hello, World!`.
- Updating the shared text constant fixes the production behavior at the source used by the CLI command.

## Testing

- `bun test`
