### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- Running the `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- No setup, configuration, or workflow changes are required for users.

## Technical Summary

- Updated `currentText` in `src/cli.ts` to `"Hello, World!"`.
- Aligned the e2e expectation in `tests/e2e.test.ts` to the new output.

## Why

- The previous output `Hello via Bun!` did not match the specification in issue #1, which requires the canonical `Hello, World!` greeting.

## Testing

- `bun test` — all 6 tests pass.
