### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo operator", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("modulo", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The `calc` CLI command now supports the modulo operator (`%`) in addition to `+`, `-`, `*`, and `/`.
- Users can compute remainders directly, e.g. `calc 10 % 3` prints `1`.
- No breaking changes; existing operators continue to work exactly as before.

## Technical Summary

- Extended the `Operator` union type in `src/cli.ts` to include `"%"` and added a `%` case to the `calculate` switch.
- Updated `src/index.ts` yargs `choices` and the operator cast to include `"%"`, so the CLI accepts and validates the new operator.
- Added unit and E2E tests asserting `10 % 3 === 1`, covering both the pure function and the CLI surface.

## Why

- The issue requested modulo support alongside the existing four arithmetic operations.
- Mirroring the existing switch/choices pattern keeps the change minimal and consistent with the surrounding code.

## Testing

- `bun test` — all 8 tests pass across `tests/unit.test.ts` and `tests/e2e.test.ts`.

## Notes

- None.
