### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`, matching the documented expected output.
- No migration or configuration changes required; users running the CLI will simply see the corrected greeting.

## Technical Summary

- Updated `currentText` in `src/cli.ts` from `"Hello via Bun!"` to `"Hello, World!"`.
- Updated the e2e test in `tests/e2e.test.ts` to assert the new expected stdout.

## Why

- The issue reported the CLI output was incorrect; the greeting should be the canonical `Hello, World!`.
- Changing the single shared constant is the smallest fix that keeps the test and production code aligned.

## Testing

- `bun test` — all 6 tests pass.

## Notes

- None.
