### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/.antigravitycli/ab54550c-6933-4387-bcec-edd614bdc813.json
+++ b/.antigravitycli/ab54550c-6933-4387-bcec-edd614bdc813.json
@@ -1,0 +1,1 @@
+/Users/exkazuu/.gemini/config/projects/ab54550c-6933-4387-bcec-edd614bdc813.json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

Print "Hello, World!" instead of "Hello via Bun!".