### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!`.
- Users no longer see the old `Hello via Bun!` message.
- No rollout or migration steps are required.

## Technical Summary

- Updated the exported CLI text in `src/cli.ts`.
- The e2e test covers the real Bun CLI path and expects the new output.
- No dependencies, configuration, or command behavior changed beyond the printed text.

## Why

- The issue requested the CLI greeting to be changed from `Hello via Bun!` to `Hello, World!`.
- Updating the shared `currentText` value keeps the command behavior aligned with the existing CLI implementation.

## Testing

- `bun test`
