### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- No migration or rollout steps are required; behavior change is limited to the output of one command.

## Technical Summary

- Updated `currentText` in `src/cli.ts` from `"Hello via Bun!"` to `"Hello, World!"`.
- Updated the corresponding e2e expectation in `tests/e2e.test.ts`.

## Why

- The issue requested that the `hello` command print `Hello, World!`.
- A single-string change at the source of truth keeps the diff minimal and aligned with the existing test structure.

## Testing

- `bun test` (6 passed, 0 failed)

## Notes

- None.