### PR TITLE
fix: print Hello World greeting

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!`.
- This replaces the previous `Hello via Bun!` message with the requested greeting.
- No rollout, compatibility, or migration steps are needed.

## Technical Summary

- Updated the exported CLI greeting constant in `src/cli.ts`.
- The E2E CLI test covers the real `hello` command path and expects the exact stdout value.
- No dependency, configuration, or architecture changes were made.

## Why

- The CLI behavior did not match the requested greeting text.
- Updating the shared greeting constant keeps the fix minimal and preserves the existing command implementation.

## Testing

- `bun test`
