### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- Users get the expected greeting text when running the real CLI.
- No migration or rollout steps are needed.

## Technical Summary

- Updated the exported CLI greeting text in `src/cli.ts`.
- The existing E2E CLI coverage now asserts the `hello` command exits successfully, writes no stderr, and prints the new exact stdout.
- No dependencies, configuration, or CLI argument behavior changed.

## Why

- The CLI greeting did not match the requested output.
- Updating the shared `currentText` export fixes the production behavior at the source used by the `hello` command.

## Testing

- `bun test`
