### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test('hello prints "Hello, World!"', async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!`.
- Users see the expected greeting instead of the previous Bun-specific message.
- No rollout, compatibility, or migration steps are required.

## Technical Summary

- Updated the exported CLI text constant in `src/cli.ts` from `Hello via Bun!` to `Hello, World!`.
- The E2E coverage verifies the real `bun run src/index.ts hello` command exits successfully, emits no stderr, and prints the exact expected stdout.
- No dependencies, configuration, or architecture were changed.

## Why

- The CLI greeting did not match the requested output.
- Updating the shared text constant fixes the command at the production source used by the CLI.

## Testing

- `bun test`
