### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- Users and automation that rely on the command get the expected greeting text.
- No rollout, compatibility, or migration steps are needed.

## Technical Summary

- Updated the exported CLI greeting text in `src/cli.ts`.
- Kept the e2e coverage for `bun run src/index.ts hello`, which verifies exit status, stderr, and stdout.
- No dependencies, configuration, or architecture changed.

## Why

- The CLI output did not match the requested behavior or the new regression test.
- Updating the shared greeting constant fixes the user-visible command output with the smallest production-code change.

## Testing

- `bun test`
