### PR TITLE
fix: print Hello, World from hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- Users and automated checks will see the requested greeting when running the command.
- No rollout, compatibility, or migration steps are needed.

## Technical Summary

- Updated the production `currentText` value used by the CLI `hello` command.
- Updated E2E coverage to run `bun run src/index.ts hello` and assert the exact stdout, empty stderr, and successful exit code.
- No configuration, dependency, or architecture changes were required.

## Why

- The CLI output did not match the requested greeting.
- Changing the shared text constant is the smallest production fix because the command already prints that value directly.

## Testing

- `bun test`
