### PR TITLE
feat: support modulo operator

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
       },
       "devDependencies": {
         "@types/bun": "1.3.5",
+        "@types/yargs": "17.0.35",
         "sort-package-json": "3.6.0",
         "typescript": "5.9.3",
       },
@@ -18,6 +19,10 @@
     "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
+
+    "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
+
+    "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "module": "src/index.ts",
   "devDependencies": {
     "@types/bun": "1.3.5",
+    "@types/yargs": "17.0.35",
     "sort-package-json": "3.6.0",
     "typescript": "5.9.3"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import yargs from "yargs";
+import type { ArgumentsCamelCase, Argv } from "yargs";
 import { hideBin } from "yargs/helpers";
 import { calculate, currentText } from "./cli";
+import type { Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -14,7 +16,7 @@ yargs(hideBin(process.argv))
   .command(
     "calc <left> <operator> <right>",
     "Calculate a result from two numbers and an operator",
-    (cmd) =>
+    (cmd: Argv) =>
       cmd
         .positional("left", {
           type: "number",
@@ -22,17 +24,15 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
           type: "number",
           demandOption: true,
         }),
-    (argv) => {
-      const left = argv.left as number;
-      const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+    (argv: ArgumentsCamelCase<{ left: number; operator: Operator; right: number }>) => {
+      const { left, operator, right } = argv;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("calculates remainder", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The calculator CLI now accepts the modulo operator (`%`) in addition to addition, subtraction, multiplication, and division.
- Users can run commands such as `calc 10 % 4` and receive the remainder as the printed result.
- This is backward compatible with existing calculator commands and does not require migration.

## Technical Summary

- Extended the shared `Operator` type and `calculate` switch to support `%`.
- Added `%` to the yargs positional operator choices for the `calc` command.
- Added `@types/yargs` and explicit yargs callback typings so strict TypeScript verification passes for the touched CLI entrypoint.
- Added E2E CLI coverage for modulo and a focused calculator API test matching the existing test style.

## Why

- The calculator previously supported only the four basic arithmetic operations, but the issue requested modulo support as another arithmetic operator.
- The implementation follows the existing operator dispatch and CLI validation paths so the feature is available through the same user-facing workflow as the other operations.

## Testing

- `bun test`
- `bunx tsc --noEmit`
