### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of the previous `Hello via Bun!`.
- No other user-visible behavior changes; the `calc` command is unaffected.
- No migration or compatibility concerns.

## Technical Summary

- Changed `currentText` in `src/cli.ts` from `"Hello via Bun!"` to `"Hello, World!"`.
- The reproducing e2e test in `tests/e2e.test.ts` ("cli" > "hello prints Hello, World!") now asserts the corrected output and passes.

## Why

- The `hello` command emitted an incorrect greeting. The issue requested printing the standard `Hello, World!` string.
- Updating the single source constant is the minimal, correct fix and keeps the output centralized.

## Testing

- `bun test` — all 6 tests pass (0 fail).

## Notes

- No breaking changes.
