### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc computes the modulo result", async () => {
+    const result = await runCli(["calc", "17", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("computes modulo", () => {
+    expect(calculate(17, "%", 5)).toBe(2);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The `calc` command now supports the modulo operator (`%`) in addition to `+`, `-`, `*`, and `/`.
- Users can compute remainders directly, e.g. `calc 17 % 5` prints `2`.
- No breaking changes; all existing operators behave exactly as before.

## Technical Summary

- `src/cli.ts`: extended the `Operator` union type with `"%"` and added a `case "%": return left % right;` branch in `calculate()`.
- `src/index.ts`: added `"%"` to the yargs `operator` positional `choices` and widened the operator cast to include `"%"`.
- `tests/unit.test.ts`: added a unit test asserting `calculate(17, "%", 5) === 2`.
- `tests/e2e.test.ts`: added an end-to-end test that spawns the real CLI `calc 17 % 5` and asserts exit code 0, empty stderr, and stdout `"2"`.

## Why

- The issue requested supporting the modulo operator alongside the four arithmetic operations.
- Mirroring the existing operator-handling pattern keeps the change minimal, consistent, and easy to review.

## Testing

- `bun test` — 8 pass, 0 fail (14 expect calls).
- `bunx tsc --noEmit` — clean, no type errors.

## Notes

- None.
