### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!`.
- Users no longer see the old `Hello via Bun!` message when running the command.
- This is a small output correction with no migration or compatibility steps required.

## Technical Summary

- Updated `src/cli.ts` to change the exported `currentText` value used by the `hello` command.
- The existing E2E coverage runs `bun run src/index.ts hello` and verifies the exit code, stderr, and stdout.
- No command parsing, dependencies, or calculation behavior changed.

## Why

- The CLI output did not match the expected user-facing greeting.
- Updating the shared output constant is the narrowest production change and keeps the existing command implementation intact.

## Testing

- `bun test`
