### PR TITLE
fix: print Hello, World

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- Users get the requested greeting text with no workflow or compatibility changes.
- No rollout or migration steps are required.

## Technical Summary

- Updated `currentText` in `src/cli.ts` to the new greeting string.
- The E2E CLI test now verifies the `hello` command exits successfully with no stderr and prints the exact expected output.
- No dependencies, configuration, or CLI argument behavior changed.

## Why

- The CLI output did not match the requested behavior.
- Reusing the existing `currentText` path keeps the fix minimal and preserves the current command structure.

## Testing

- `bun test`
