### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of the placeholder `Hello via Bun!`.
- Users running the CLI's `hello` command see the expected greeting.
- No configuration, migration, or compatibility changes are required.

## Technical Summary

- Changed the `currentText` constant in `src/cli.ts` from `"Hello via Bun!"` to `"Hello, World!"`.
- The `hello` command in `src/index.ts` logs this constant, so its output now matches the expected greeting.
- Updated the E2E expectation in `tests/e2e.test.ts` to assert the corrected stdout.

## Why

- The issue reported that the `hello` command printed a placeholder greeting (`Hello via Bun!`) rather than the intended `Hello, World!`.
- Fixing the constant at its single source keeps the value consistent across all consumers.

## Testing

- `bun test` → 6 pass, 0 fail (10 expect() calls).

## Notes

- No breaking changes.
