### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc computes modulo", async () => {
+    const result = await runCli(["calc", "13", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("3");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("computes modulo", () => {
+    expect(calculate(13, "%", 5)).toBe(3);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The calculator CLI now supports the modulo operator (`%`) in addition to the four basic arithmetic operations.
- Users can compute remainders directly, e.g. `calc 13 % 5` prints `3`.
- No breaking changes: all existing operators (`+`, `-`, `*`, `/`) continue to work exactly as before.

## Technical Summary

- `src/cli.ts`: Added `"%"` to the `Operator` union type and a `case "%": return left % right;` branch in `calculate()`.
- `src/index.ts`: Added `"%"` to the `calc` command's operator `choices` and to the operator type cast.
- `tests/unit.test.ts`: Added a unit test for `calculate(13, "%", 5) === 3`.
- `tests/e2e.test.ts`: Added an E2E CLI test asserting `calc 13 % 5` prints `3` with empty stderr and exit code 0.

## Why

- The issue requested supporting the modulo operator alongside the existing four arithmetic operations.
- The change mirrors the existing operator handling pattern for a minimal, consistent, and easily reviewable diff.

## Testing

- `bun test` → 8 pass, 0 fail (14 expect() calls across 2 files).

## Notes (if needed)

- None.
