### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!`.
- Users no longer see the old `Hello via Bun!` message.
- No rollout, compatibility, or migration steps are required.

## Technical Summary

- Updated the exported CLI text constant in `src/cli.ts`.
- Added/kept E2E coverage that runs the real `hello` command and asserts stdout is exactly `Hello, World!` with no stderr.
- The change is limited to the hello output string and does not affect calculation behavior.

## Why

- The issue requires the CLI greeting to use `Hello, World!` instead of the Bun-specific message.
- Updating the shared `currentText` constant keeps the CLI behavior aligned with the existing command implementation.

## Testing

- `bun test`
