### PR TITLE
fix: print Hello, World from hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- Users running the CLI get the expected greeting text.
- No rollout, compatibility, or migration steps are required.

## Technical Summary

- Updated the exported CLI greeting text in `src/cli.ts`.
- The e2e CLI test now runs the real `hello` command and expects the corrected output.
- The change is limited to the greeting string and its coverage.

## Why

- The previous CLI greeting did not match the requested output.
- Updating the shared `currentText` constant fixes the behavior at the source used by the command.

## Testing

- `bun test`
