### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test('hello prints "Hello, World!"', async () => {

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -31,6 +31,13 @@ describe("cli", () => {
     expect(result.stdout).toBe("Hello via Bun!");
   });
 
+  test('hello prints "Hello, World!"', async () => {
+    const result = await runCli(["hello"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("Hello, World!");
+  });
+
   test("calc prints only the number result", async () => {
     const result = await runCli(["calc", "2", "+", "3"]);
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of the previous incorrect `Hello via Bun!`.
- Users running `hello` see the expected standard greeting.
- No migration or compatibility concerns; output text only.

## Technical Summary

- Changed `currentText` in `src/cli.ts` from `"Hello via Bun!"` to `"Hello, World!"`.
- Updated the pre-existing `hello prints the current text` expectation in `tests/e2e.test.ts`, which still asserted the buggy string, to `"Hello, World!"`.
- The added failing test `hello prints "Hello, World!"` is left intact and now passes.

## Why

- The reported bug: the CLI greeting was wrong. `Hello, World!` is the intended output.
- Minimal change to the output string plus aligning the stale test expectation keeps the fix focused.

## Testing

- `bun test` => 7 pass, 0 fail.
