### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test('hello prints "Hello, World!"', async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!`.
- Users no longer see the old `Hello via Bun!` message.
- No migration or rollout steps are needed.

## Technical Summary

- Updated the exported CLI text constant in `src/cli.ts`.
- The E2E CLI test now verifies the real `hello` command exits successfully with no stderr and exactly `Hello, World!` on stdout.
- No dependencies, configuration, or CLI argument handling changed.

## Why

- The previous greeting did not match the requested user-visible behavior.
- Updating the shared production constant keeps the fix minimal and aligned with the existing CLI implementation.

## Testing

- `bun test`
