### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("hello prints \"Hello, World!\"", async () => {

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -31,6 +31,13 @@ describe("cli", () => {
     expect(result.stdout).toBe("Hello via Bun!");
   });
 
+  test("hello prints \"Hello, World!\"", async () => {
+    const result = await runCli(["hello"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("Hello, World!");
+  });
+
   test("calc prints only the number result", async () => {
     const result = await runCli(["calc", "2", "+", "3"]);
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of the previous placeholder `Hello via Bun!`.
- Anyone running the CLI sees the expected greeting; no migration or action is required.

## Technical Summary

- `src/cli.ts`: changed the exported `currentText` constant from `"Hello via Bun!"` to `"Hello, World!"`.
- `tests/e2e.test.ts`: kept the new reproducing E2E test `hello prints "Hello, World!"` and updated the pre-existing `hello prints the current text` test (which still asserted the buggy output) to expect `"Hello, World!"`.

## Why

- The `hello` command emitted an incorrect placeholder string. The fix aligns the output with the intended greeting and locks it in with an E2E test.

## Testing

- `bun test` → 7 pass, 0 fail.