### PR TITLE
fix: print Hello, World from hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- Users running the command see the expected greeting with no change to other CLI behavior.
- No rollout, compatibility, or migration steps are needed.

## Technical Summary

- Updated the shared `currentText` value in `src/cli.ts` to `Hello, World!`.
- The e2e test now asserts the corrected `hello` command output while preserving the existing checks for successful exit and empty stderr.
- No dependencies, configuration, or command parsing behavior changed.

## Why

- The previous greeting did not match the requested CLI output.
- Updating the source constant keeps the fix minimal and applies through the existing command implementation.

## Testing

- `bun test`
