### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/test/e2e/cli.test.ts
+++ b/test/e2e/cli.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "index.ts");
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {
@@ -36,5 +36,12 @@ describe("cli", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
+  });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "14", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("4");
   });
 });

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {
@@ -16,5 +16,9 @@ describe("calculate", () => {
 
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
+  });
+
+  test("returns the modulo remainder", () => {
+    expect(calculate(14, "%", 5)).toBe(4);
   });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The calculator now accepts the modulo operator (`%`) in addition to addition, subtraction, multiplication, and division.
- Users can run CLI calculations such as `calc 14 % 5` and receive the remainder as the result.
- Existing calculator behavior remains unchanged, with no migration needed.

## Technical Summary

- Extended the shared `Operator` type and `calculate` switch in `src/cli.ts` to include modulo.
- Added `%` to the yargs `calc` command operator choices in `src/index.ts` so the CLI accepts it.
- Added focused unit coverage for modulo calculation and E2E CLI coverage for the real command path.
- Moved tests into `test/unit` and `test/e2e` to match the repository testing guideline.

## Why

- The calculator previously supported only four arithmetic operators, so users could not compute remainders through the API or CLI.
- This direct implementation keeps the operator model simple and matches the existing arithmetic code path.

## Testing

- `bun test`
- `bunx tsc --noEmit`
