### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("hello prints Hello, World!", async () => {

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -31,6 +31,13 @@ describe("cli", () => {
     expect(result.stdout).toBe("Hello via Bun!");
   });
 
+  test("hello prints Hello, World!", async () => {
+    const result = await runCli(["hello"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("Hello, World!");
+  });
+
   test("calc prints only the number result", async () => {
     const result = await runCli(["calc", "2", "+", "3"]);
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of the previous `Hello via Bun!`.
- Anyone running the CLI sees the corrected greeting; no migration or configuration changes are required.

## Technical Summary

- `src/cli.ts`: changed the exported `currentText` constant from `"Hello via Bun!"` to `"Hello, World!"`.
- `tests/e2e.test.ts`: updated the pre-existing `hello prints the current text` end-to-end test, which still asserted the buggy output, to expect `Hello, World!`. The reproduction test `hello prints Hello, World!` was left intact and not weakened.

## Why

- The reported issue requires the greeting to read `Hello, World!`. The previous value was incorrect, and a stale e2e test still encoded the buggy expectation.
- A single-constant change is the minimal, correct fix matching the issue.

## Testing

- `bun test` — all 7 tests pass.

## Notes

- No breaking changes.
