### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- Users running the command get the expected greeting with no workflow or migration changes required.
- Existing calculator behavior is unchanged.

## Technical Summary

- Updated the shared CLI text constant in `src/cli.ts` to the expected greeting.
- The E2E coverage on this branch runs the real CLI and asserts the corrected stdout, zero exit code, and empty stderr.
- No dependency, configuration, or architecture changes were needed.

## Why

- The CLI output did not match the requested greeting.
- Updating the production constant is the smallest implementation that fixes the observed behavior while preserving the existing command structure.

## Testing

- `bun test`
