### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/test/e2e/cli.test.ts
+++ b/test/e2e/cli.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "index.ts");
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {
@@ -36,5 +36,12 @@ describe("cli", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
+  });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "14", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("4");
   });
 });

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {
@@ -16,5 +16,9 @@ describe("calculate", () => {
 
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
+  });
+
+  test("returns the remainder", () => {
+    expect(calculate(14, "%", 5)).toBe(4);
   });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- Calculator users can now use the modulo operator (`%`) in addition to addition, subtraction, multiplication, and division.
- CLI calculations such as `calc 14 % 5` return the expected remainder.
- No migration or compatibility steps are required for existing arithmetic commands.

## Technical Summary

- Added `%` to the shared `Operator` type and `calculate` implementation.
- Added `%` to the yargs `calc` operator choices and reused the shared `Operator` type in the CLI handler.
- Moved existing tests into `test/unit` and `test/e2e` and added modulo coverage at both the calculate API and real CLI levels.

## Why

- The calculator previously supported only four arithmetic operations and rejected modulo in the CLI.
- The implementation extends the existing switch-based operator handling directly, keeping the change small and consistent with the current code.

## Testing

- `bun test`
- `bunx tsc --noEmit`
