### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints "Hello, World!" instead of the previous "Hello via Bun!".
- Users running the CLI will see the corrected, expected greeting text.
- No migration or configuration changes are required.

## Technical Summary

- Changed the `currentText` constant in `src/cli.ts` from "Hello via Bun!" to "Hello, World!".
- The `hello` yargs command prints this constant, so its output now matches the expected value.
- The accompanying E2E test in `tests/e2e.test.ts` asserts the corrected output.

## Why

- The reported bug was that the CLI printed the wrong greeting ("Hello via Bun!").
- Updating the single source-of-truth constant is the minimal, correct fix.

## Testing

- `bun test` → 6 pass, 0 fail (10 expect() calls).
- Verified the failing E2E test "hello prints the current text" now passes.
