### PR TITLE
fix: print Hello, World! greeting

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- Users see the requested greeting text with no workflow or compatibility changes.
- No rollout or migration steps are required.

## Technical Summary

- Updated the exported CLI greeting text in `src/cli.ts`.
- The existing e2e coverage asserts that `bun run src/index.ts hello` exits successfully, writes no stderr, and prints the exact expected stdout.
- No dependency, configuration, or architecture changes were needed.

## Why

- The CLI was returning the wrong greeting for the `hello` command.
- The fix keeps the behavior scoped to the current text value used by the command.

## Testing

- `bun test`
