### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- Users running the CLI's `hello` subcommand see the expected greeting text.
- No migration or compatibility concerns; behavior is otherwise unchanged.

## Technical Summary

- Changed `currentText` in `src/cli.ts` from `"Hello via Bun!"` to `"Hello, World!"`.
- The `hello` command in `src/index.ts` logs `currentText`, so its stdout now matches the expected value.
- Updated the e2e expectation in `tests/e2e.test.ts` accordingly.

## Why

- The issue requested printing `Hello, World!` instead of `Hello via Bun!`.
- A one-line constant change is the minimal, correct fix that satisfies the failing e2e test.

## Testing

- `bun test` → 6 pass, 0 fail (10 expect() calls), including `tests/e2e.test.ts` > cli > "hello prints the current text".
