### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!`.
- Users no longer see the older `Hello via Bun!` message.
- No rollout, compatibility, or migration steps are needed.

## Technical Summary

- Updated the exported `currentText` value in `src/cli.ts`.
- The e2e test expectation for `hello` now asserts the requested output.
- No dependencies, configuration, or architecture changed.

## Why

- The CLI was printing the wrong greeting for the requested behavior.
- Updating the shared greeting constant fixes the command at the source while keeping the existing CLI flow unchanged.

## Testing

- `bun test`
