### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("hello prints Hello, World!", async () => {

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -31,6 +31,13 @@ describe("cli", () => {
     expect(result.stdout).toBe("Hello via Bun!");
   });
 
+  test("hello prints Hello, World!", async () => {
+    const result = await runCli(["hello"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("Hello, World!");
+  });
+
   test("calc prints only the number result", async () => {
     const result = await runCli(["calc", "2", "+", "3"]);
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
Close #1

Close #322

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- No change to how the command is invoked; only the printed message differs.
- No migration or configuration steps required.

## Technical Summary

- Updated the `currentText` constant in `src/cli.ts` to `"Hello, World!"`.
- Updated the existing e2e assertion that hard-coded the old output and added a dedicated e2e test asserting the new output in `tests/e2e.test.ts`.

## Why

- The prior output `Hello via Bun!` was incorrect; the intended greeting is `Hello, World!`.
- Changing the single source-of-truth constant is the minimal, correct fix.

## Testing

- `bun test` → 7 pass, 0 fail (7 tests across 2 files).