### PR TITLE
fix: print Hello, World from hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` as requested.
- Users no longer see the old `Hello via Bun!` message.
- No rollout steps or migration work are needed.

## Technical Summary

- Updated the CLI text exported from `src/cli.ts`.
- Kept the e2e regression test coverage for the real `hello` command entrypoint.
- No dependencies, configuration, or architecture were changed.

## Why

- The CLI output did not match the expected greeting.
- A single constant update fixes the behavior while preserving the existing command flow.

## Testing

- `bun test`
