### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- This aligns the command output with the requested behavior and the updated end-to-end test.
- No rollout, compatibility, or migration steps are required.

## Technical Summary

- Updated `currentText` in `src/cli.ts` to the new greeting string.
- The existing `hello` command continues to print the shared `currentText` value.
- The branch also includes an E2E assertion that verifies successful execution, empty stderr, and the expected stdout.

## Why

- The CLI previously returned the old Bun greeting for `hello`.
- Updating the shared text constant is the smallest production change that fixes the command while preserving the current CLI structure.

## Testing

- `bun test`
