### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {

--- a/tests/hello.e2e.test.ts
+++ b/tests/hello.e2e.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+
+async function runCli(args: string[]) {
+  const proc = Bun.spawn(["bun", "run", entry, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return {
+    stdout: stdout.trim(),
+    stderr: stderr.trim(),
+    exitCode,
+  };
+}
+
+describe("cli hello greeting", () => {
+  test('hello prints "Hello, World!"', async () => {
+    const result = await runCli(["hello"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("Hello, World!");
+  });
+});


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- No other user-visible behavior changes; the `calc` command is unaffected.

## Technical Summary

- Updated `currentText` in `src/cli.ts` to `"Hello, World!"`.
- Updated the existing e2e assertion in `tests/e2e.test.ts` to expect the new greeting.
- Added `tests/hello.e2e.test.ts` covering the `hello` command output end-to-end.

## Why

- The issue requested the greeting be changed to `Hello, World!`. The source was updated but a stale test expectation caused `bun test` to fail on this branch; aligning the test with the intended behavior fixes the regression.

## Testing

- `bun test` — all 7 tests pass (0 fail).
