### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- No other user-visible behavior changes; the greeting text is the only difference.

## Technical Summary

- Updated `currentText` in `src/cli.ts` to `"Hello, World!"`.
- The e2e test in `tests/e2e.test.ts` asserts the `hello` command outputs `Hello, World!` with exit code 0 and empty stderr.

## Why

- The reported bug requested the greeting be the canonical `Hello, World!` rather than the placeholder `Hello via Bun!`.

## Testing

- `bun test tests/e2e.test.ts` — 2 pass, 0 fail.
