### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc computes modulo", async () => {
+    const result = await runCli(["calc", "17", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("computes modulo", () => {
+    expect(calculate(17, "%", 5)).toBe(2);
+  });
 });


### PR DESCRIPTION
Close #4

Close #324

## Customer Summary

- The `calc` command now supports the modulo operator (`%`) in addition to the four basic arithmetic operations (`+`, `-`, `*`, `/`).
- Users can compute remainders directly, e.g. `calc 17 % 5` prints `2`.
- No breaking changes; existing operators behave exactly as before.

## Technical Summary

- Extended the `Operator` union type with `"%"` and added a `case "%"` branch returning `left % right` in `calculate` (`src/cli.ts`).
- Added `"%"` to the CLI `operator` positional `choices` and widened the operator cast in `src/index.ts`.
- Added a unit test for `calculate(17, "%", 5) === 2` and an e2e CLI test asserting `calc 17 % 5` prints `2`.

## Why

- The issue requested modulo support alongside the existing four arithmetic operations.
- Mirroring the existing switch/choices pattern keeps the change minimal and consistent with the current design.

## Testing

- `bun test` — all 8 tests pass (14 assertions).

## Notes (if needed)

- None.