### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints the greeting", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- No configuration, migration, or compatibility impact; only the greeting text shown to users changes.

## Technical Summary

- Updated `currentText` in `src/cli.ts` to `"Hello, World!"`.
- Updated the e2e test in `tests/e2e.test.ts` to assert the `hello` command outputs `Hello, World!`.

## Why

- The issue requested the greeting be `Hello, World!` rather than `Hello via Bun!`.
- The minimal code + test change aligns behavior with the expected output and locks it in with an e2e assertion.

## Testing

- `bun test` — 6 pass, 0 fail.