### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc computes the modulo", async () => {
+    const result = await runCli(["calc", "13", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("3");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("computes the modulo", () => {
+    expect(calculate(13, "%", 5)).toBe(3);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The `calc` command now supports the modulo operator (`%`) in addition to the four existing arithmetic operators (`+`, `-`, `*`, `/`).
- Users can compute remainders directly, e.g. `calc 13 % 5` prints `3`.
- No breaking changes: all existing operators and behaviors are unchanged.

## Technical Summary

- `src/cli.ts`: extended the `Operator` union type with `"%"` and added a `case "%"` branch in `calculate` returning `left % right`.
- `src/index.ts`: added `"%"` to the `calc` command's `operator` `choices` and to the argv type cast so the CLI accepts and validates it.
- `tests/unit.test.ts`: added a unit test asserting `calculate(13, "%", 5) === 3`.
- `tests/e2e.test.ts`: added a CLI end-to-end test asserting `calc 13 % 5` prints `3` with exit code 0 and empty stderr.

## Why

- Issue #4 requests supporting the modulo operator alongside the four arithmetic operations.
- The change follows the existing operator-handling pattern (union type + switch case + CLI choices), keeping the implementation minimal and consistent with the current design.

## Testing

- `bun test` — all 8 tests pass (0 fail), including the new unit and E2E modulo tests.

## Notes

- No breaking changes or migrations required.