### PR TITLE
fix: print Hello, World greeting

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` CLI command now prints `Hello, World!` instead of `Hello via Bun!`.
- No migration or configuration changes are required.

## Technical Summary

- Updated the greeting exported by `src/cli.ts`.
- Updated the CLI end-to-end expectation to cover the corrected stdout while retaining successful-exit and empty-stderr checks.

## Why

- The `hello` command returned the wrong user-visible greeting.
- Changing the shared greeting constant is the smallest implementation fix and keeps the CLI behavior covered through the real command entry point.

## Testing

- `bun test tests/e2e.test.ts`
- `bun test`
- `bunx tsc --noEmit`
