### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- Running the `hello` command now prints `Hello, World!` instead of the placeholder `Hello via Bun!`.
- This only changes the greeting text that users see. No other command, option, or workflow behaves differently.
- Nothing to migrate and nothing to roll out carefully: anyone who upgrades simply sees the corrected greeting the next time they run the command.

## Technical Summary

- Changed the `currentText` constant in `src/cli.ts` from `"Hello via Bun!"` to `"Hello, World!"`.
- Updated the stdout assertion in the existing `cli > hello prints the current text` case in `tests/e2e.test.ts` to expect the corrected string.
- Scope is limited to those two lines. The `calc` command, the `Operator` type, and the argument parsing are all untouched.

## Why

- The `hello` command shipped with a leftover scaffold string, so its output did not match the greeting the project intends to print.
- A single exported constant already backs the command's output, so correcting that constant fixes the behavior at its source without touching the command wiring or introducing indirection.

## Testing

- `bun test` — 6 tests pass, 0 fail, across 2 files.
- The e2e test spawns the real CLI via `bun run src/index.ts hello` and asserts on stdout, exit code 0, and empty stderr, so the corrected greeting is verified end-to-end rather than only at the constant.

## Notes

- No breaking changes. The greeting string is not part of a public API and is not parsed by any other code.
