### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc computes the remainder", async () => {
+    const result = await runCli(["calc", "13", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("3");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("computes the remainder", () => {
+    expect(calculate(13, "%", 5)).toBe(3);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The `calc` command now supports the modulo operator (`%`) in addition to `+`, `-`, `*`, and `/`. For example, `calc 13 % 5` prints `3`.
- Nothing else changes: every operator that worked before behaves exactly as it did, so this is purely additive and needs no migration or rollout steps.
- Previously `%` was rejected as an invalid choice, so anyone wanting a remainder had no way to get one from the CLI.

## Technical Summary

- `src/cli.ts`: added `"%"` to the `Operator` union and a `case "%": return left % right;` branch to `calculate`. The switch has no `default`, so TypeScript's exhaustiveness check on the return type is what forces every union member to be handled.
- `src/index.ts`: added `"%"` to the yargs `choices` array for the `operator` positional, which is what actually lets the value through argument validation.
- `src/index.ts`: replaced the inline `argv.operator as "+" | "-" | "*" | "/"` cast with the exported `Operator` type, removing a second copy of the union that would silently drift out of sync when operators are added.
- Semantics are JavaScript's `%`, meaning the result takes the sign of the dividend and `x % 0` yields `NaN`, consistent with how the existing `/` case already delegates to the language operator.

## Why

- Issue #4 asks for the modulo operator alongside the four arithmetic operations.
- The operator was added at both layers it has to pass through — the `Operator` type/switch and the yargs `choices` list — because either one alone leaves the feature broken: a missing `choices` entry rejects the input before `calculate` is ever reached.
- Using the `Operator` type at the call site instead of a repeated literal union keeps the next operator addition to two edits rather than three.

## Testing

- `bun test` — 8 passing, 0 failing.
- `bunx tsc --noEmit` — clean.
- Added a unit test in `tests/unit.test.ts` asserting `calculate(13, "%", 5) === 3`.
- Added an E2E test in `tests/e2e.test.ts` that spawns the real CLI with `calc 13 % 5` and asserts stdout is exactly `3` with exit code 0. This is the test that carries the weight: a missing `choices` entry fails here and would pass the unit test.
- Manually verified against the real CLI: `bun run src/index.ts calc 13 % 5` prints `3`, and `calc 7 % 2` prints `1`.

## Notes

- No breaking changes; existing operators and their output are untouched.
