### PR TITLE
fix: print "Hello, World!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test('hello prints "Hello, World!"', async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- No migration or rollout action is required.

## Technical Summary

- Update the CLI output constant used by the `hello` command.
- Update the end-to-end regression test to require the exact expected output while continuing to verify a successful exit and empty stderr.

## Why

- The CLI returned the Bun-specific placeholder text instead of the intended greeting.
- Changing the shared output constant is the smallest production fix and preserves the existing command behavior.

## Testing

- `bun test` (6 passed, 0 failed)
- `bunx tsc --noEmit` (reports pre-existing missing `yargs` type declarations and related implicit `any` errors)
