### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("calculates the remainder", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- Adds the modulo (`%`) operator to the calculator alongside addition, subtraction, multiplication, and division.
- Users can now calculate remainders directly from the CLI, for example `calc 10 % 3` returns `1`.
- This is backward compatible and requires no migration or rollout steps.

## Technical Summary

- Extends the `Operator` type and calculation switch to support `%`.
- Adds `%` to the CLI's accepted operator choices.
- Covers remainder calculation with both a unit test and a full CLI end-to-end test.

## Why

- The calculator previously supported only the four basic arithmetic operations and could not calculate remainders.
- Extending the existing operator validation and calculation paths keeps the implementation consistent and focused.

## Testing

- `bun test` — 8 tests passed, 0 failed.
- `bun run src/index.ts calc 10 % 3` — printed `1`.

## Notes

- `bunx tsc --noEmit` continues to report the pre-existing missing `@types/yargs` declarations and related implicit-any errors; this is unchanged from the base branch.
