### PR TITLE
fix: print "Hello, World!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- No migration or rollout steps are required.

## Technical Summary

- Updated the exported CLI greeting used by the `hello` command.
- Updated the end-to-end test to verify the exact expected greeting while retaining successful-exit and empty-stderr checks.

## Why

- The CLI exposed an implementation-specific greeting rather than the required user-facing message.
- Updating the shared greeting constant is the smallest change that corrects the real command output.

## Testing

- `bun test tests/e2e.test.ts` (2 passed, 0 failed)
- `bun test` (6 passed, 0 failed)
- `bunx tsc --noEmit` (reports pre-existing missing `yargs` declarations and related implicit-`any` errors in `src/index.ts`)
