### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- Anyone scripting against the previous output text will see the new string; no flags, arguments, or exit codes changed.
- No migration or configuration steps are needed.

## Technical Summary

- Updated the `currentText` constant in `src/cli.ts` to `"Hello, World!"`.
- Updated the corresponding expectation in the `hello prints the current text` E2E case in `tests/e2e.test.ts`.
- No other modules, dependencies, or CLI behavior were touched.

## Why

- The greeting text leaked the runtime ("via Bun") into user-facing output rather than printing the conventional `Hello, World!` message requested in the issue.
- Changing the single exported constant keeps the fix at its source, so every consumer of `currentText` stays consistent.

## Testing

- `bun test` — 6 passed, 0 failed (10 assertions across 2 files), including the previously failing E2E case that spawns the real CLI via `bun run src/index.ts hello` and checks exit code, stderr, and stdout.

## Notes

- Technically a breaking change for anything matching on the exact old output string, though this is the intended behavior change.
