### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc computes the remainder with %", async () => {
+    const result = await runCli(["calc", "13", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("3");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("computes the remainder", () => {
+    expect(calculate(13, "%", 5)).toBe(3);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The `calc` command now accepts `%` in addition to `+`, `-`, `*`, and `/`, so users can compute remainders directly (e.g. `calc 13 % 5` prints `3`).
- No change to any existing operator's behavior or output format, so current usage is unaffected.
- No migration or rollout steps are needed; the new operator is available as soon as the change ships.

## Technical Summary

- `src/cli.ts`: extended the `Operator` union with `"%"` and added the matching `case "%"` to `calculate`, returning `left % right`.
- `src/index.ts`: added `"%"` to the `calc` positional `choices` so yargs accepts it, and replaced the inlined operator union cast with the exported `Operator` type.
- Tests: added a unit test for `calculate(13, "%", 5)` and an e2e test that runs the real CLI process for `calc 13 % 5`.

## Why

- The issue asked for modulo support alongside the four existing arithmetic operations.
- The operator set is validated in two places (the yargs `choices` array and the `calculate` switch), so both had to be updated for the feature to work end-to-end. Importing `Operator` in `src/index.ts` instead of repeating the literal union removes one of the two spots where the operator list was duplicated, so the cast can no longer silently drift from the real type.

## Testing

- `bun test` — 8 pass, 0 fail. The e2e test spawns the actual CLI and asserts exit code 0, empty stderr, and stdout `3`, so it also covers the yargs `choices` gate: without that change the command would exit non-zero.

## Notes

- No breaking changes.
- `bunx tsc --noEmit` reports 4 pre-existing errors in `src/index.ts`, all caused by missing yargs typings (`@types/yargs` is not installed, making `yargs`, `yargs/helpers`, and the `cmd`/`argv` params implicitly `any`). These are unrelated to this change and were left alone, since fixing them means adding a dependency. Worth a separate issue if a clean typecheck is desired.
