### PR TITLE
fix: print Hello, World!

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- Make the `hello` CLI command print `Hello, World!` instead of `Hello via Bun!`.
- Users receive the expected standard greeting; no migration or configuration changes are required.

## Technical Summary

- Update the exported `currentText` value used by the `hello` command.
- Update the end-to-end CLI regression test to assert the corrected stdout while retaining its exit-code and stderr checks.
- No other commands or runtime behavior are changed.

## Why

- The `hello` command returned the wrong greeting.
- Changing the shared production constant is the smallest fix and keeps the externally visible behavior covered through the real CLI entry point.

## Testing

- `bun test tests/e2e.test.ts` — passes (2 tests).
- `bun test` — passes (6 tests).
- `git diff --check` — passes.
- `bunx tsc --noEmit` — reports pre-existing missing `yargs` declaration and related implicit-`any` errors in `src/index.ts`; this PR does not modify those types or code paths.
