### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints the greeting", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of the previous `Hello via Bun!`.
- This only changes the greeting text shown to users; no other behavior, options, or commands are affected.
- No migration or action is required for anyone using the CLI.

## Technical Summary

- Changed the `currentText` constant in `src/cli.ts` to `"Hello, World!"`.
- Updated the corresponding e2e expectation in `tests/e2e.test.ts` and renamed the case to `hello prints the greeting`.
- No other modules, dependencies, or configuration touched.

## Why

- The issue reported that the CLI printed a Bun scaffolding placeholder string rather than the intended greeting.
- Fixing the shared `currentText` constant keeps the single source of truth for the greeting and requires no changes at the command wiring in `src/index.ts`.

## Testing

- `bun test` — 6 pass, 0 fail (10 assertions across 2 files), including the e2e case that spawns the CLI as a real subprocess and asserts exit code, empty stderr, and stdout.
