### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports the modulo operator", async () => {
+    const result = await runCli(["calc", "13", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("3");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("takes the modulo", () => {
+    expect(calculate(13, "%", 5)).toBe(3);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The `calc` command now accepts `%` alongside `+`, `-`, `*`, and `/`, so users can compute remainders directly (e.g. `calc 13 % 5` prints `3`).
- `%` also appears in the operator list shown by `--help`, so it is discoverable the same way the other operators are.
- Purely additive: every existing command and operator behaves exactly as before, so there is nothing to migrate and no reason to hold back the rollout.

## Technical Summary

- `src/cli.ts`: added `"%"` to the `Operator` union and a `case "%": return left % right;` branch to `calculate`.
- `src/index.ts`: added `"%"` to the yargs `choices` for the `operator` positional, and replaced the inline, duplicated operator union with the exported `Operator` type.
- Limitation worth noting: `%` follows JavaScript's remainder semantics, so the sign of the result follows the dividend (`-7 % 3` is `-1`, not `2`). This matches how the other operators already delegate to native JS arithmetic.

## Why

- Issue #4 asked for modulo support in addition to the four arithmetic operations.
- The operator was defined in three places (the type, the `switch`, and the yargs `choices`), and updating only the first two would leave the CLI rejecting `%` at argument-validation time before `calculate` ran. All three were updated, and importing `Operator` in `src/index.ts` removes one of the duplicates so the type and the cast can no longer drift apart.

## Testing

- `bun test` — 8/8 pass. Added `calculate(13, "%", 5) === 3` to `tests/unit.test.ts` and an end-to-end case in `tests/e2e.test.ts` that spawns the real CLI with `calc 13 % 5` and asserts stdout `3`, exit code `0`, and empty stderr. The e2e case is the load-bearing one: it fails against the pre-change code because yargs' `strict()` choices validation rejects `%` before `calculate` is reached.
- Manual verification: `bun run src/index.ts calc 13 % 5` prints `3`, and `--help` lists `%` among the operator choices.

## Notes

- No breaking changes.
- `bunx tsc --noEmit` reports 4 errors, all from the missing `@types/yargs` declarations. These were confirmed pre-existing by re-running the check against a stashed tree; they are unrelated to this change and left as-is.
- Pre-existing bug found while testing, not addressed here: a negative left operand (`calc -7 % 3`) is parsed by yargs as an option rather than a positional and fails. This affects all five operators equally and predates modulo, so it is left for separate follow-up.
