### PR TITLE
fix: print Hello, World from hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- Users receive the expected greeting with no compatibility or migration steps required.

## Technical Summary

- Updated the CLI greeting constant used by the `hello` command.
- Updated the end-to-end CLI test to assert the corrected output while retaining successful-exit and empty-stderr checks.

## Why

- The existing greeting did not match the required user-visible behavior.
- Changing the shared greeting constant is the smallest production fix and keeps the command implementation unchanged.

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `git diff --check`
