### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- Running the `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- This is the only user-visible change; no other command output, flags, or workflows are affected.
- No migration or configuration steps are needed — the new text appears as soon as the update is installed.

## Technical Summary

- Updated the `currentText` constant in `src/cli.ts` to `"Hello, World!"`.
- Updated the corresponding e2e assertion in `tests/e2e.test.ts` so the `hello` subprocess test expects the new stdout.
- No API surface, dependency, or architecture changes; `calculate` and the rest of the CLI are untouched.

## Why

- The CLI shipped with a placeholder greeting inherited from the project scaffold, which did not match the intended output.
- Changing the single exported constant keeps the fix at its source, so every consumer of `currentText` stays consistent without duplicating the string.

## Testing

- `bun test` — 6 tests pass across 2 files, including the e2e test that spawns the real CLI via `bun run src/index.ts hello` and asserts exit code 0, empty stderr, and stdout `Hello, World!`.
