### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports the modulo operator", async () => {
+    const result = await runCli(["calc", "13", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("takes the remainder", () => {
+    expect(calculate(13, "%", 4)).toBe(1);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The `calc` command now accepts `%` (modulo) alongside `+`, `-`, `*`, and `/`, so you can ask for the remainder of a division directly: `calc 13 % 4` prints `1`.
- `%` shows up in `--help` as a valid operator choice, and an invalid operator still fails with the same clear usage message as before.
- Purely additive — every existing command and operator behaves exactly as it did, so there is nothing to migrate.

## Technical Summary

- `src/cli.ts`: added `"%"` to the `Operator` union and a matching `case "%"` in `calculate` returning `left % right`.
- `src/index.ts`: added `"%"` to the `calc` positional `choices`, and replaced the inline, hand-duplicated operator union with the exported `Operator` type.
- Tests: a unit case for `calculate(13, "%", 4) === 1` and an E2E case asserting `calc 13 % 4` prints `1` with exit code 0 and empty stderr.
- Semantics follow JavaScript's `%`, so the result takes the sign of the dividend (`-7 % 3 === -1`).

## Why

- Requested in #4: extend the calculator beyond the four basic arithmetic operations.
- The operator list previously lived in two places — the `Operator` union in `cli.ts` and a duplicate literal union in `index.ts`'s argv cast. Importing `Operator` at the cast site means a future operator only has to be declared once, and the two can no longer silently drift apart.

## Testing

- `bun test` — 8 tests pass across `tests/unit.test.ts` and `tests/e2e.test.ts`.
- `bunx tsc --noEmit` — clean.
- Manual: `bun run src/index.ts calc 13 % 4` prints `1`.

## Notes

- No breaking changes. Passing a negative left operand on the command line requires the usual yargs escaping for leading-dash arguments; that is pre-existing CLI behavior and untouched here.
