### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc supports modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("calculates the remainder", () => {
+    expect(calculate(10, "%", 4)).toBe(2);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- Add modulo (`%`) calculations alongside addition, subtraction, multiplication, and division.
- CLI users can now run commands such as `calc 10 % 4` and receive `2`.
- This is backward-compatible and requires no migration.

## Technical Summary

- Extend the calculator's `Operator` type and switch implementation with `%`.
- Add `%` to the yargs positional operator choices and command-handler type.
- Cover modulo behavior with calculator unit coverage and a spawned CLI end-to-end test.

## Why

- The calculator previously supported only four arithmetic operations and rejected modulo at the CLI boundary.
- Supporting `%` in both the calculator and argument validation keeps the public API and CLI behavior aligned.

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `git diff --check`
