### PR TITLE
fix: print Hello, World! from hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- This is a direct output correction with no migration or compatibility steps required.

## Technical Summary

- Updated the CLI's exported greeting string in `src/cli.ts`.
- Updated the end-to-end CLI expectation to cover the corrected stdout while continuing to verify a successful exit and empty stderr.

## Why

- The `hello` command returned the wrong greeting.
- Changing the shared greeting value is the smallest fix and preserves the existing command behavior.

## Testing

- `bun test` — passed: 6 tests, 0 failures.
- `bunx tsc --noEmit` — currently reports pre-existing missing `@types/yargs` declarations and related implicit-`any` errors in `src/index.ts`.
