### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/test/unit/modulo.test.ts
+++ b/test/unit/modulo.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
+
+test("calc prints the remainder for the modulo operator", async () => {
+  const proc = Bun.spawn(["bun", "run", entry, "calc", "17", "%", "5"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("2");
+});


### PR DESCRIPTION
Close #4

## Customer Summary

- Add `%` as a supported calculator operator so users can obtain the remainder after division.
- Existing addition, subtraction, multiplication, and division behavior remains unchanged.
- No rollout steps or migrations are required.

## Technical Summary

- Extend the shared `Operator` type and calculation switch with modulo support.
- Accept `%` in the `calc` command's validated operator choices and reuse the shared operator type in the command handler.
- Add a real-process CLI test that verifies `calc 17 % 5` exits successfully and prints `2` without errors.

## Why

- The calculator supported four basic arithmetic operations but could not calculate remainders.
- Extending the existing operator type, CLI validation, and calculation switch keeps the implementation consistent with the other arithmetic operators.

## Testing

- `bun test` (7 passed, 0 failed)

## Notes

- `bunx tsc --noEmit` continues to report pre-existing missing `yargs` declaration files and implicit-any errors in `src/index.ts`.
