### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -28,7 +28,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- No other user-visible behavior changes; existing calc functionality is unaffected.

## Technical Summary

- Changed `currentText` in `src/cli.ts` from `"Hello via Bun!"` to `"Hello, World!"`.
- The `hello` CLI command in `src/index.ts` logs this value unchanged.

## Why

- The reported issue requested that the CLI greet with the conventional `Hello, World!` message rather than the default Bun template string.

## Testing

- `bun test` — 6 pass, 0 fail (includes the e2e test asserting `hello` prints `Hello, World!` on stdout with exit code 0 and empty stderr).
