### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as "+" | "-" | "*" | "/" | "%";
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc computes the modulo result", async () => {
+    const result = await runCli(["calc", "17", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,8 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("computes the remainder", () => {
+    expect(calculate(17, "%", 5)).toBe(2);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The `calc` command now supports the modulo (`%`) operator in addition to the four basic arithmetic operations (`+`, `-`, `*`, `/`).
- Users can compute remainders directly, e.g. `calc 17 % 5` prints `2`.
- No breaking changes; all existing operators behave exactly as before.

## Technical Summary

- `src/cli.ts`: Added `"%"` to the `Operator` union type and a `case "%": return left % right;` branch in `calculate`.
- `src/index.ts`: Added `"%"` to the yargs positional `choices` and the operator cast type so the CLI accepts and forwards the new operator.
- Added a unit test (`tests/unit.test.ts`) and an end-to-end CLI test (`tests/e2e.test.ts`) covering modulo behavior.

## Why

- The issue requested modulo support alongside the four arithmetic operations. A prior commit with the same title only added stray worktree files and never implemented the operator, so this change implements it for real.
- Extending the existing `Operator` union and switch keeps the change minimal and consistent with the surrounding code.

## Testing

- `bun test` → 8 pass, 0 fail.
- Manual CLI verification: `bun run src/index.ts calc 17 % 5` → `2`.

## Notes (if needed)

- `tsc --noEmit` reports pre-existing errors about missing `yargs` type declarations; these are unrelated to this change and exist independently on the base branch.
