### PR TITLE
fix: print Hello, World! from hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {
@@ -28,7 +34,7 @@ describe("cli", () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- This is a direct output correction with no migration or compatibility impact.

## Technical Summary

- Updated the exported `currentText` constant in `src/cli.ts`.
- Kept the CLI behavior test that verifies a successful exit, empty stderr, and the exact expected stdout.

## Why

- The command returned outdated text that did not match the required greeting.
- Updating the single source constant is the smallest change that corrects the externally visible behavior.

## Testing

- `bun test test/unit/cli.test.ts` — 2 passed, 0 failed.
- `bun test` — 6 passed, 0 failed.

## Notes

- `bunx tsc --noEmit` still reports pre-existing missing type declarations for `yargs` and related implicit-`any` errors in `src/index.ts`; these are unrelated to this fix.
