### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/";
+export type Operator = "+" | "-" | "*" | "/" | "%";
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {
@@ -12,5 +12,7 @@ export function calculate(left: number, operator: Operator, right: number): numb
       return left * right;
     case "/":
       return left / right;
+    case "%":
+      return left % right;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { calculate, currentText } from "./cli";
+import { calculate, currentText, type Operator } from "./cli";
 
 yargs(hideBin(process.argv))
   .command(
@@ -22,7 +22,7 @@ yargs(hideBin(process.argv))
         })
         .positional("operator", {
           type: "string",
-          choices: ["+", "-", "*", "/"] as const,
+          choices: ["+", "-", "*", "/", "%"] as const,
           demandOption: true,
         })
         .positional("right", {
@@ -32,7 +32,7 @@ yargs(hideBin(process.argv))
     (argv) => {
       const left = argv.left as number;
       const right = argv.right as number;
-      const operator = argv.operator as "+" | "-" | "*" | "/";
+      const operator = argv.operator as Operator;
 
       console.log(calculate(left, operator, right));
     },

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -37,4 +37,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("5");
   });
+
+  test("calc computes the modulo", async () => {
+    const result = await runCli(["calc", "10", "%", "3"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,4 +17,12 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
+
+  test("takes the remainder", () => {
+    expect(calculate(10, "%", 3)).toBe(1);
+  });
+
+  test("takes the remainder of a negative left operand", () => {
+    expect(calculate(-10, "%", 3)).toBe(-1);
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- The `calc` command now supports the modulo operator (`%`) alongside the existing four arithmetic operations, so `calc 10 % 3` prints `1`.
- `%` appears in the command's help text and is accepted as a valid operator; passing an unsupported operator still fails with a message listing every valid choice.
- Purely additive — every existing operator (`+`, `-`, `*`, `/`) and the `hello` command behave exactly as before, so there is nothing to migrate and no action required for existing users.

## Technical Summary

- `src/cli.ts`: added `"%"` to the `Operator` union and a `case "%": return left % right;` branch to `calculate`.
- `src/index.ts`: added `"%"` to the `calc` positional's `choices` so yargs accepts the operator, and replaced the duplicated inline `"+" | "-" | "*" | "/"` cast with the exported `Operator` type.
- Both the type and the CLI `choices` list had to change: `calculate` alone would still be rejected by yargs' `choices` validation before ever being called.
- Limitation: `%` follows plain JavaScript semantics, so `calc 10 % 0` prints `NaN`. This matches the existing unguarded behavior of `/` (which prints `Infinity`), so no divide-by-zero handling was introduced for either operator.

## Why

- Requested in #4: support the modulo operator in addition to the four arithmetic operations.
- The change mirrors the existing per-operator structure (union member + `switch` case + `choices` entry) rather than introducing an operator table or validation layer, keeping the diff minimal and consistent with the surrounding code.
- Reusing the exported `Operator` type in `src/index.ts` removes a second hand-maintained copy of the operator list, so a future operator cannot be added to the type while the CLI cast silently drifts out of sync.

## Testing

- CI: the GitHub Actions `test` workflow passes on `eaad57d`; the PR is `MERGEABLE` / `CLEAN` and up to date with `main`.
- `bun test` — 9 pass, 0 fail.
- `bunx tsc --noEmit` — reports 4 pre-existing errors from the missing `@types/yargs`; verified identical output on the base commit by stashing the change, so they are unrelated to this PR.
- Added `tests/e2e.test.ts` "calc computes the modulo": spawns the real CLI and asserts `calc 10 % 3` prints `1` with exit 0 and empty stderr. This is the meaningful coverage — without the `src/index.ts` change it fails on the exit code, not just the output.
- Added `tests/unit.test.ts` cases for `calculate(10, "%", 3) === 1` and `calculate(-10, "%", 3) === -1`, matching the existing per-operator test style.
- Manually drove the built CLI: `10 % 3` → `1`, `-10 % 3` → `-1`, `7.5 % 2` → `1.5`, `10 % 0` → `NaN`, `12 / 3` → `4` (unchanged), `hello` → `Hello via Bun!` (unchanged), and `calc 1 ^ 2` rejected with `Choices: "+", "-", "*", "/", "%"`.

## Notes (if needed)

- No breaking changes; the change is additive to an existing command.
- `/gemini review` was requested on this PR but no review had arrived after ~15 minutes of polling, so this PR has not yet received automated review feedback.
- This branch was developed in an isolated git worktree because the shared checkout was being concurrently rewritten by agents working on #1 and #167 (the yargs-to-commander migration). This PR is based on `main` and intentionally contains only the modulo change — it does not include or depend on the commander migration.
