### PR TITLE
fix: print "Hello, World!" instead of "Hello via Bun!"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- Anyone or anything relying on the previous `Hello via Bun!` output text needs to expect the new wording.
- No other commands, options, or workflows change.

## Technical Summary

- `src/cli.ts`: changed the exported `currentText` constant to `"Hello, World!"`.
- `tests/e2e.test.ts`: updated the end-to-end expectation and test name for the `hello` subcommand.
- No API surface, dependency, or configuration changes.

## Why

- The issue reported that the CLI greeting should be the conventional `Hello, World!`.
- Changing the single source-of-truth constant keeps the fix minimal and keeps the greeting defined in one place.

## Testing

- `bun test` — 6 passed, 0 failed.
