### PR TITLE
fix: print Hello, World! from the hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "index.ts");
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {
@@ -24,11 +24,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- Existing calculator behavior is unchanged, and no rollout or migration is required.

## Technical Summary

- Update the greeting exported by `src/cli.ts`.
- Organize the existing tests under `test/unit` and exercise the real CLI entry point.
- Verify the `hello` command's exit code, stderr, and exact stdout value.

## Why

- The CLI returned the wrong user-visible greeting because its production text constant still contained the Bun-specific message.
- Updating the shared greeting constant is the smallest change that fixes the command without altering command routing or unrelated behavior.

## Testing

- `bun test test/unit/cli.test.ts` (2 passed)
- `bun test` (6 passed)
- Latest GitHub Actions workflows passed for commit `f1ab579`.
- `bunx tsc --noEmit` (reports existing missing `yargs` declarations and related implicit-`any` errors in `src/index.ts`)

## Notes

- The existing TypeScript declaration errors are outside this bug fix and remain unchanged.
