### PR TITLE
fix: print Hello, World! when running the CLI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,9 @@ function parseNumber(value: string): number {
 
 const program = new Command();
 
-program.name("agent-benchmark");
+program.name("agent-benchmark").action(() => {
+  console.log(currentText);
+});
 
 program
   .command("hello")

--- a/test/e2e/hello.test.ts
+++ b/test/e2e/hello.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+test("running the CLI prints Hello, World!", async () => {
+  const process = Bun.spawn(["bun", "run", "src/index.ts"], {
+    cwd: projectRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  expect(stdout).toBe("Hello, World!\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Close #1

## Customer Summary

- Running the documented `bun run src/index.ts` command now prints `Hello, World!`.
- Existing `hello` and calculator subcommands continue to work as before.
- No rollout steps or compatibility changes are required.

## Technical Summary

- Add a default action to the root Commander command that prints the existing `currentText` value.
- Add an end-to-end regression test that runs the documented CLI command as a real subprocess and checks stdout, stderr, and the exit code.

## Why

- The root CLI previously had no default action, so running the documented command exited successfully without producing output.
- A root action is the smallest fix and preserves all existing subcommand behavior.

## Testing

- `bun test test/e2e/hello.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- Manual verification: `bun run src/index.ts` prints `Hello, World!`
