### PR TITLE
fix: print Hello, World! when running the CLI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,9 @@ function parseNumber(value: string): number {
 
 const program = new Command();
 
-program.name("agent-benchmark");
+program.name("agent-benchmark").action(() => {
+  console.log(currentText);
+});
 
 program
   .command("hello")

--- a/test/unit/hello.test.ts
+++ b/test/unit/hello.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
+
+test("running the CLI prints Hello, World!", async () => {
+  const process = Bun.spawn(["bun", "run", entry], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  expect(stdout).toBe("Hello, World!\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Close #1

## Customer Summary

- Running the CLI without a subcommand now prints `Hello, World!` as expected.
- Existing `hello` and calculator commands continue to work unchanged.
- No rollout steps, compatibility changes, or migration are required.

## Technical Summary

- Add a root Commander action that prints the shared `currentText` greeting.
- Add a CLI-level regression test that launches the real entry point and verifies stdout, stderr, and the exit code.
- Keep the implementation scoped to the CLI entry point without changing subcommand behavior.

## Why

- After the CLI migrated to Commander, invoking it without a subcommand exited successfully but produced no output.
- A root action restores the intended default greeting while reusing the same greeting value as the `hello` subcommand.

## Testing

- `bun test test/unit/hello.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- Manually verified `bun run src/index.ts`, `bun run src/index.ts hello`, and `bun run src/index.ts calc 7 % 4`.
