### PR TITLE
refactor: centralize arithmetic operator definitions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);


### PR DESCRIPTION
Close #4

## Customer Summary

- Keeps modulo (`%`) and the existing arithmetic operations available through the calculator CLI.
- There is no change to command usage or calculation results.
- No rollout steps or migration are required.

## Technical Summary

- Defines the supported operator values once in `src/cli.ts`.
- Derives the `Operator` TypeScript type from that shared tuple.
- Reuses the same tuple for Commander's CLI argument validation, preventing the runtime choices and compile-time type from drifting apart.

## Why

- The CLI choices and `Operator` union previously duplicated the supported operator list.
- A single source of truth makes future operator changes safer while preserving the current behavior.

## Testing

- `bun test` (8 tests passed)
- `bunx tsc --noEmit`
- `git diff --check`
