### PR TITLE
feat: support modulo operator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {
@@ -16,11 +16,5 @@ describe("calculate", () => {
 
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
-  });
-
-  test("computes the remainder", () => {
-    expect(calculate(13, "%", 5)).toBe(3);
-    expect(calculate(-13, "%", 5)).toBe(-3);
-    expect(calculate(7.5, "%", 2)).toBe(1.5);
   });
 });

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {
@@ -38,10 +44,16 @@ describe("cli", () => {
     expect(result.stdout).toBe("5");
   });
 
-  test("calc computes the modulo of two numbers", async () => {
-    const result = await runCli(["calc", "13", "%", "5"]);
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("3");
+  test.each([
+    ["13", "5", "3"],
+    ["-13", "5", "-3"],
+    ["7.5", "2", "1.5"],
+  ])("calc computes %s modulo %s", async (left, right, expected) => {
+    const result = await runCli(["calc", left, "%", right]);
+    expect(result).toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: expected,
+    });
   });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- Adds modulo (`%`) calculations alongside the existing addition, subtraction, multiplication, and division operations.
- Supports modulo calculations for integers, negative values, and decimal values through the CLI.
- Requires no migration or configuration changes.

## Technical Summary

- Uses one exported operator tuple as the source of truth for both Commander argument validation and the `Operator` TypeScript type.
- Keeps the modulo implementation in the shared `calculate` function and exercises it through the real CLI process.
- Organizes automatically run tests under `test/unit` and consolidates modulo coverage into the broader CLI test.

## Why

- Users need remainder calculations in addition to the four existing arithmetic operations.
- Sharing the supported operator definition prevents the CLI choices and calculation type from drifting apart.

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `git diff --check`
