### PR TITLE
refactor: centralize calculator operators and strengthen modulo tests

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {
@@ -16,11 +16,5 @@ describe("calculate", () => {
 
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
-  });
-
-  test("computes the remainder", () => {
-    expect(calculate(13, "%", 5)).toBe(3);
-    expect(calculate(-13, "%", 5)).toBe(-3);
-    expect(calculate(7.5, "%", 2)).toBe(1.5);
   });
 });

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "index.ts");
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {
@@ -38,10 +38,14 @@ describe("cli", () => {
     expect(result.stdout).toBe("5");
   });
 
-  test("calc computes the modulo of two numbers", async () => {
-    const result = await runCli(["calc", "13", "%", "5"]);
+  test.each([
+    ["13", "5", "3"],
+    ["-13", "5", "-3"],
+    ["7.5", "2", "1.5"],
+  ])("calc computes %s %% %s as %s", async (left, right, expected) => {
+    const result = await runCli(["calc", left, "%", right]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("3");
+    expect(result.stdout).toBe(expected);
   });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- Keeps modulo calculations covered for positive integers, negative values, and decimal values through the real command-line workflow.
- Existing calculator commands and output remain compatible; no rollout or migration is required.

## Technical Summary

- Defines the supported operator tuple once and derives the `Operator` type from it, so CLI validation and calculation types cannot drift apart.
- Moves automatically discovered tests under `test/unit` in accordance with the repository testing conventions.
- Consolidates modulo coverage into CLI-level tests that execute the real entry point for integer, negative, and decimal operands.

## Why

- A single source of truth makes future operator additions safer and prevents the accepted CLI choices from diverging from the TypeScript operator type.
- CLI-level assertions verify the externally visible modulo behavior without duplicating production arithmetic logic in narrow unit tests.

## Testing

- `bun test` (9 passed, 0 failed)
- `bunx tsc --noEmit`
- `bun run src/index.ts calc 29 % 6` (output: `5`)
