### PR TITLE
test: cover commander-based CLI parsing behavior

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,4 +44,40 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
   });
+
+  test("--help lists the available commands", async () => {
+    const result = await runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Usage: agent-benchmark");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc");
+  });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "2", "^", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'^'");
+  });
+
+  test("calc rejects a non-numeric operand", async () => {
+    const result = await runCli(["calc", "abc", "+", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'abc' is not a number.");
+  });
+
+  test("calc rejects a missing operand", async () => {
+    const result = await runCli(["calc", "2", "+"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("missing required argument");
+  });
+
+  test("an unknown command fails", async () => {
+    const result = await runCli(["greet"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("unknown command");
+  });
 });


### PR DESCRIPTION
Close #167

Follow-up to #167 (the yargs → commander migration itself already landed on `main` via #569).

## Customer Summary

- No behavior change: the `agent-benchmark` CLI works exactly as before (`hello`, `calc <left> <operator> <right>` with `+ - * / %`).
- Adds automated checks that the CLI keeps giving clear, correct feedback for bad input — unknown operators, non-numeric operands, missing arguments, and unknown commands now all have guaranteed error messages and non-zero exit codes.
- Reduces the risk that a future change to the CLI argument handling silently breaks usage errors or the `--help` listing.

## Technical Summary

- `tests/e2e.test.ts`: five new CLI-level tests that spawn the real entry point (`bun run src/index.ts`) as a subprocess and assert stdout/stderr/exit code.
  - `--help` prints `Usage: agent-benchmark` and lists both `hello` and `calc`.
  - `calc 2 ^ 3` fails with a non-zero exit and an error naming the rejected value (commander's `Argument.choices`).
  - `calc abc + 3` fails with `'abc' is not a number.` (the custom `InvalidArgumentError` parser in `src/index.ts`).
  - `calc 2 +` fails with `missing required argument`.
  - An unknown command (`greet`) fails with `unknown command`.
- No production code changed. `src/index.ts` already uses commander (`Command`, `Argument().choices()`, `InvalidArgumentError`) and yargs is absent from source, `package.json`, and `bun.lock`.

## Why

- Issue #167 asked to employ commander instead of yargs. On inspection the migration was already complete on `main`, but it shipped with only happy-path coverage (`hello`, `calc 2 + 3`, `calc 13 % 5`).
- The parts of the commander migration most likely to regress are exactly the ones that were untested: choice validation, the custom numeric parser, arity checks, and unknown-command handling.
- Tests are written at the CLI/subprocess level rather than against commander internals, so they assert externally visible behavior and stay valid if the argument-parsing library is swapped again.

## Testing

- `bun test` → 13 pass, 0 fail, 32 expect() calls (was 8 pass before this change).
- `bun run src/index.ts hello` → `Hello, World!`

## Notes

- No breaking changes; test-only diff.
- Typecheck was not run in this environment: devDependencies are not installed (`node_modules/.bin` is empty, no local `typescript`/`@types/bun`), and a standalone `bunx tsc` reports pre-existing errors on unmodified files because it cannot see Bun's types. Run `bun install` before typechecking.