### PR TITLE
fix: print greeting when run without arguments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,9 @@ function parseNumber(value: string): number {
 
 const program = new Command();
 
-program.name("agent-benchmark");
+program.name("agent-benchmark").action(() => {
+  console.log(currentText);
+});
 
 program
   .command("hello")

--- a/test/e2e/hello.test.ts
+++ b/test/e2e/hello.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
+
+test("running the application prints Hello, World!", async () => {
+  const process = Bun.spawn(["bun", "run", entry], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  expect({ exitCode, stderr, stdout }).toEqual({
+    exitCode: 0,
+    stderr: "",
+    stdout: "Hello, World!\n",
+  });
+});


### PR DESCRIPTION
Close #1

## Customer Summary

- Running the application without arguments now prints `Hello, World!` and exits successfully.
- Existing `hello` and calculator commands remain unchanged, with no migration required.

## Technical Summary

- Add a root Commander action that writes the existing `currentText` greeting.
- Add an end-to-end regression test covering the documented no-argument entry point, exact stdout, empty stderr, and successful exit status.

## Why

- Commander previously treated a no-argument invocation as an error and printed help to stderr instead of the expected greeting.
- A root action restores the intended default behavior while retaining all existing subcommands.

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `git diff --check`
