### PR TITLE
feat: strengthen modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {
@@ -16,11 +16,5 @@ describe("calculate", () => {
 
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
-  });
-
-  test("computes the remainder", () => {
-    expect(calculate(13, "%", 5)).toBe(3);
-    expect(calculate(-13, "%", 5)).toBe(-3);
-    expect(calculate(7.5, "%", 2)).toBe(1.5);
   });
 });

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "index.ts");
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {
@@ -38,10 +38,14 @@ describe("cli", () => {
     expect(result.stdout).toBe("5");
   });
 
-  test("calc computes the modulo of two numbers", async () => {
-    const result = await runCli(["calc", "13", "%", "5"]);
+  test.each([
+    ["13", "5", "3"],
+    ["-13", "5", "-3"],
+    ["7.5", "2", "1.5"],
+  ])("calc computes %s %% %s as %s", async (left, right, expected) => {
+    const result = await runCli(["calc", left, "%", right]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("3");
+    expect(result.stdout).toBe(expected);
   });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- Modulo calculations work through the CLI for positive, negative, and decimal values.
- Existing arithmetic commands remain compatible, with no migration or rollout steps required.

## Technical Summary

- Centralize the supported arithmetic operators, including `%`, in a single readonly definition shared by CLI validation and the `Operator` type.
- Derive the operator type from that definition to prevent the CLI choices and calculation API from drifting apart.
- Consolidate modulo coverage into CLI-level tests under `test/unit`, exercising argument parsing and output for positive, negative, and decimal operands.

## Why

- Modulo support must remain consistent across the public CLI and the typed calculation implementation.
- A single source of truth reduces maintenance risk, while CLI-level coverage verifies the complete user-visible path without duplicating implementation logic in narrow tests.

## Testing

- `bun test` (9 passed, 0 failed)
- `bunx tsc --noEmit`
- `git diff --check`
