### PR TITLE
fix: print "Hello, World!" from the hello command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/";
 

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {
@@ -24,11 +30,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello via Bun!");
+    expect(result.stdout).toBe("Hello, World!");
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #4

Close #1

## Customer Summary

- The `hello` command now prints `Hello, World!` instead of `Hello via Bun!`.
- No other command behavior changes; `calc` output is unchanged.
- No migration or configuration steps are needed.

## Technical Summary

- `src/cli.ts`: `currentText` changed from `"Hello via Bun!"` to `"Hello, World!"`; this constant is what `src/index.ts` prints for the `hello` subcommand.
- The CLI end-to-end test moved from `tests/e2e.test.ts` to `test/unit/cli.test.ts` (entry-path join updated for the extra directory level), and the `hello` case now asserts the exact expected string.

## Why

- The greeting text was Bun's scaffolding default rather than the intended output requested in the issue.
- Changing the single exported constant keeps the fix minimal and keeps the string in one place, so the CLI command handler needs no change.

## Testing

- `bun install`
- `bun test` → 6 pass, 0 fail
- `bun run src/index.ts hello` → prints `Hello, World!`

## Notes

- No breaking changes.