### PR TITLE
fix: print Hello, World from documented command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,9 @@ function parseNumber(value: string): number {
 
 const program = new Command();
 
-program.name("agent-benchmark");
+program.name("agent-benchmark").action(() => {
+  console.log(currentText);
+});
 
 program
   .command("hello")

--- a/test/unit/hello.test.ts
+++ b/test/unit/hello.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+test('running the application prints "Hello, World!"', async () => {
+  const process = Bun.spawn(["bun", "run", "src/index.ts"], {
+    cwd: projectRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  expect(stdout).toBe("Hello, World!\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Close #1

## Customer Summary

- Running the documented `bun run src/index.ts` command now prints `Hello, World!`.
- The command exits successfully without writing errors, restoring the expected default behavior.
- No migration or compatibility action is required.

## Technical Summary

- Add a root Commander action that prints the existing `currentText` value when no subcommand is provided.
- Add a subprocess regression test covering exact stdout, empty stderr, and a successful exit code for the documented command.
- Existing `hello` and `calc` subcommands remain unchanged.

## Why

- The CLI previously had no root action, so invoking the documented command without a subcommand produced no output.
- Reusing `currentText` keeps the default command and the `hello` subcommand consistent without duplicating the greeting.

## Testing

- `bun test test/unit/hello.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run src/index.ts`
