### PR TITLE
refactor: keep calculator operators in sync

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {


### PR DESCRIPTION
Close #4

## Customer Summary

- Keeps modulo calculations available through the `calc` command alongside addition, subtraction, multiplication, and division.
- Prevents the command-line validation and calculator implementation from accidentally supporting different operator sets in future changes.
- Requires no migration or workflow changes for users.

## Technical Summary

- Defines the supported operator tuple once in `src/cli.ts` and derives the `Operator` type from it.
- Reuses that tuple for Commander argument validation in `src/index.ts`.
- Moves calculator and CLI coverage under `test/unit` so the tests follow the repository testing guidelines and remain automatically discoverable.
- Retains direct calculation coverage for integer, negative, and decimal modulo operands plus an end-to-end CLI invocation.

## Why

- The operator union and CLI choices previously duplicated the same values, allowing them to drift apart.
- A single source of truth preserves compile-time type safety and runtime validation with minimal implementation complexity.

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `bun run src/index.ts calc 29 % 6`
- `bun run src/index.ts calc -13 % 5`
- `bun run src/index.ts calc 7.5 % 2`
