### PR TITLE
feat: harden modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -38,10 +38,16 @@ describe("cli", () => {
     expect(result.stdout).toBe("5");
   });
 
-  test("calc computes the modulo of two numbers", async () => {
-    const result = await runCli(["calc", "13", "%", "5"]);
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("3");
+  test.each([
+    ["13", "5", "3"],
+    ["-13", "5", "-3"],
+    ["7.5", "2", "1.5"],
+  ])("calc computes %s %% %s as %s", async (left, right, expected) => {
+    const result = await runCli(["calc", left, "%", right]);
+    expect(result).toEqual({
+      stdout: expected,
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- Ensures the calculator consistently accepts the modulo (`%`) operator through the command-line interface.
- Verifies remainder calculations for positive integers, negative values, and decimal values.
- No migration or usage changes are required.

## Technical Summary

- Defines the supported arithmetic operators once and derives the `Operator` type from that shared list.
- Reuses the shared operator list for Commander argument validation, preventing runtime validation and TypeScript types from drifting apart.
- Expands end-to-end CLI coverage for modulo calculations across representative numeric inputs.

## Why

- The modulo operator must remain supported consistently by both the calculation layer and CLI validation.
- A single source of truth keeps future operator changes type-safe and reduces maintenance risk.

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `git diff --check`
