### PR TITLE
test: cover commander-based CLI parsing behavior

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,4 +44,48 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
   });
+
+  test("calc accepts negative operands instead of treating them as options", async () => {
+    const result = await runCli(["calc", "-13", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("-3");
+  });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "13", "^", "5"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'^' is invalid for argument 'operator'");
+    expect(result.stderr).toContain("+, -, *, /, %");
+  });
+
+  test("calc rejects a non-numeric operand", async () => {
+    const result = await runCli(["calc", "a", "+", "1"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'a' is not a number.");
+  });
+
+  test("calc reports a missing operand", async () => {
+    const result = await runCli(["calc", "1", "+"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("missing required argument 'right'");
+  });
+
+  test("an unknown command fails with an error", async () => {
+    const result = await runCli(["bogus"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("unknown command 'bogus'");
+  });
+
+  test("--help lists the available commands", async () => {
+    const result = await runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Usage: agent-benchmark");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc <left> <operator> <right>");
+  });
 });


### PR DESCRIPTION
Close #167

## Customer Summary

- No user-visible behavior changes. The `agent-benchmark` CLI works exactly as before: `hello` prints `Hello, World!` and `calc <left> <operator> <right>` evaluates `+`, `-`, `*`, `/`, and `%`.
- This change locks in the behavior of the commander-based CLI with automated tests, so future edits cannot silently break argument handling or error messages.
- No rollout, compatibility, or migration steps are needed.

## Technical Summary

- The commander migration itself was already merged to `main` (`dd2c9b1`): `src/index.ts` is built on `commander`'s `Command` / `Argument().choices()` / `InvalidArgumentError`, and neither `package.json` nor `bun.lock` references `yargs` anymore. This branch adds the missing test coverage for it.
- Extends `tests/e2e.test.ts` with six CLI-level tests that spawn the real entry point and assert stdout, stderr, and exit code:
  - `calc -13 % 5` → `-3`, guarding against a leading-dash operand being parsed as an option
  - unsupported operator `^` → non-zero exit plus the allowed-choices message
  - non-numeric operand → non-zero exit plus `'a' is not a number.`
  - missing operand → `missing required argument 'right'`
  - unknown command → non-zero exit
  - `--help` → usage banner listing `hello` and `calc <left> <operator> <right>`
- Tests live in `tests/e2e.test.ts` to match this repository's existing layout; no production code was modified.

## Why

- The pre-existing suite only exercised three happy paths, so nothing pinned the parsing and error-reporting behavior that commander is responsible for — a regression or a swap back to another parser would have gone unnoticed.
- CLI-level tests that spawn the real binary were chosen over unit tests around the parser so the assertions cover externally visible behavior (stdout, stderr, exit status) rather than internal wiring.

## Testing

- `bun install` — no changes, 16 installs across 17 packages
- `bun test` — 14 pass, 0 fail, 36 expect() calls across 2 files
- Manually exercised the CLI for each new case (`bun run src/index.ts calc 13 ^ 5`, `... calc a + 1`, `... calc -13 % 5`, `... bogus`, `... --help`) and confirmed the messages and exit codes the tests assert.

## Notes

- No breaking changes.
- Leftover `yargs` files remain in the local `node_modules` (not pruned by `bun install`) and inside unrelated checked-out worktrees under `.claude/worktrees/`; the tracked manifest and lockfile are clean, so nothing was changed there.
