### PR TITLE
refactor: centralize supported arithmetic operators

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/test/unit/calculator.test.ts
+++ b/test/unit/calculator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {


### PR DESCRIPTION
Close #4

## Customer Summary

- Keeps modulo and the four existing arithmetic operators available through the calculator CLI.
- Prevents the accepted CLI operators and calculator implementation from drifting apart as operator support evolves.
- Requires no migration or rollout action from users.

## Technical Summary

- Defines the supported operator tuple in `src/cli.ts` and derives the `Operator` type from it.
- Reuses the same tuple for Commander CLI argument validation in `src/index.ts`.
- Moves calculator and real CLI subprocess tests under `test/unit` so they are in the repository's required automatic test-discovery location.
- Retains coverage for modulo through the CLI and for positive, negative, and fractional remainder calculations.

## Why

- Maintaining separate runtime choices and a TypeScript union can allow them to diverge.
- A single source of truth keeps runtime validation and compile-time types synchronized with minimal code.

## Testing

- `bun test test/unit/cli.test.ts test/unit/calculator.test.ts`
- `bunx tsc --noEmit`
- `bun test`
