### PR TITLE
test: cover commander-based CLI parsing and validation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export type Operator = "+" | "-" | "*" | "/" | "%";
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello, World!";
+export const currentText = "Hello via Bun!";
 
 export type Operator = "+" | "-" | "*" | "/" | "%";
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,4 +44,47 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
   });
+
+  test("calc divides into a fractional result", async () => {
+    const result = await runCli(["calc", "7", "/", "2"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("3.5");
+  });
+
+  test("--help lists both commands", async () => {
+    const result = await runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Usage: agent-benchmark");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc <left> <operator> <right>");
+  });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "1", "^", "2"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Allowed choices are +, -, *, /, %.");
+  });
+
+  test("calc rejects a non-numeric operand", async () => {
+    const result = await runCli(["calc", "x", "+", "2"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'x' is not a number.");
+  });
+
+  test("calc reports a missing operand", async () => {
+    const result = await runCli(["calc", "1", "+"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("missing required argument 'right'");
+  });
+
+  test("an unknown command fails", async () => {
+    const result = await runCli(["bogus"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("unknown command 'bogus'");
+  });
 });


### PR DESCRIPTION
Close #4

Close #167

## Customer Summary

- No user-visible behavior changes. The `agent-benchmark` CLI keeps the same two commands, `hello` and `calc`, and produces the same output as before, including `hello` printing `Hello, World!`.
- This change strengthens the automated safety net around the CLI, so mistakes in argument handling (bad operators, non-numeric operands, missing arguments, unknown commands) are caught before release rather than by users.
- The migration this issue asked for — replacing `yargs` with `commander` — is already live on `main` (it landed in #569). Nothing needs to be rolled out or migrated here.

## Technical Summary

- Adds six end-to-end CLI tests to `tests/e2e.test.ts`, each spawning the real CLI as a subprocess and asserting exit code, stdout, and stderr:
  - fractional division (`calc 7 / 2` -> `3.5`)
  - `--help` shows the `agent-benchmark` program name and both subcommands
  - unsupported operator rejected by commander's `.choices()` (`calc 1 ^ 2`)
  - non-numeric operand rejected by the custom `parseNumber` parser (`calc x + 2`)
  - missing required argument (`calc 1 +`)
  - unknown command (`bogus`)
- The net diff against `main` is `tests/e2e.test.ts` only (+43 lines). The branch also carries a commit that temporarily changed `currentText` to `Hello via Bun!` and a follow-up commit that restored `Hello, World!`; those two cancel out, so `src/`, `package.json`, and `bun.lock` are byte-identical to `main`.
- No production code changes. `src/index.ts` already builds the CLI with `Command`, `Argument`, and `InvalidArgumentError` from `commander@15.0.0`, and neither `package.json` nor `bun.lock` references `yargs` or `@types/yargs`.
- The only remaining `yargs` strings in the repository are inside `.claude/worktrees/*` gitlinks, which point at unrelated worktrees and are not part of this project's build.

## Why

- The issue asked to install and use `commander` and remove `yargs`. Verification against `main` showed that work already merged in #569, so rewriting it would have produced churn with no behavior change.
- What was genuinely missing was coverage of the commander-specific surface: argument coercion, `.choices()` validation, required-argument errors, and help output were all untested, so a regression in any of them would have gone unnoticed.
- The tests drive the real CLI as a subprocess instead of asserting on parser configuration, which follows the project's testing guidelines: prefer the broadest practical test that checks externally visible behavior, and avoid tests that only assert assembled parameters.

## Testing

- `bun test` -> 14 pass, 0 fail, 35 expect() calls across 2 files.
- `bunx tsc --noEmit` -> clean.
- Manually exercised each error path via `bun run src/index.ts ...` to confirm the asserted commander messages and non-zero exit codes match real output.
- CI on the head commit: all workflows passed.

## Notes

- The PR title uses the `test:` prefix because the net diff against `main` is test-only; the `feat:` work for this issue is already on `main`.
- Follow-up (intentionally not done here to avoid unrelated restructuring): the shared testing guidelines expect tests under `test/unit` and `test/e2e`, while this repo uses `tests/unit.test.ts` and `tests/e2e.test.ts` and runs them via `bun test` directly.
