### PR TITLE
refactor: keep modulo operator support consistent

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -38,10 +38,14 @@ describe("cli", () => {
     expect(result.stdout).toBe("5");
   });
 
-  test("calc computes the modulo of two numbers", async () => {
-    const result = await runCli(["calc", "13", "%", "5"]);
+  test.each([
+    ["13", "5", "3"],
+    ["-13", "5", "-3"],
+    ["7.5", "2", "1.5"],
+  ])("calc computes %s %% %s", async (left, right, expected) => {
+    const result = await runCli(["calc", left, "%", right]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("3");
+    expect(result.stdout).toBe(expected);
   });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,10 +17,4 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
-
-  test("computes the remainder", () => {
-    expect(calculate(13, "%", 5)).toBe(3);
-    expect(calculate(-13, "%", 5)).toBe(-3);
-    expect(calculate(7.5, "%", 2)).toBe(1.5);
-  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- Keeps modulo calculations working consistently through the command-line calculator.
- Covers positive integers, negative operands, and decimal operands through real CLI executions.
- No migration or rollout action is required.

## Technical Summary

- Defines the supported arithmetic operators once and derives the `Operator` type from that canonical list.
- Reuses the same operator list for Commander argument validation, preventing the parser and calculator types from drifting apart.
- Consolidates duplicate modulo unit assertions into broader end-to-end CLI scenarios.

## Why

- The CLI parser and calculator previously maintained separate operator definitions, making future arithmetic changes easier to apply incompletely.
- A shared immutable list keeps runtime validation and TypeScript guarantees aligned, while CLI-level tests verify externally visible behavior.

## Testing

- `bun test` (9 tests passed)
- `bunx tsc --noEmit`
- `git diff --check`
