### PR TITLE
test: cover commander CLI parsing and error handling

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,4 +44,41 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
   });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "2", "^", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'^' is invalid for argument 'operator'");
+  });
+
+  test("calc rejects a non-numeric operand", async () => {
+    const result = await runCli(["calc", "x", "+", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'x' is not a number.");
+  });
+
+  test("calc reports a missing operand", async () => {
+    const result = await runCli(["calc", "2", "+"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("missing required argument 'right'");
+  });
+
+  test("an unknown command fails", async () => {
+    const result = await runCli(["bogus"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("unknown command 'bogus'");
+  });
+
+  test("--help lists both commands", async () => {
+    const result = await runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Usage: agent-benchmark");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc <left> <operator> <right>");
+  });
 });


### PR DESCRIPTION
Close #167

## Customer Summary

- No user-visible or behavioral change. The `agent-benchmark` CLI works exactly as before.
- This change adds automated checks that lock in how the CLI responds to bad input, so future changes cannot silently break error messages or exit codes.
- No rollout, compatibility, or migration steps are required.

## Technical Summary

- The commander migration requested in #167 was already merged in dd2c9b1 (#569): `src/index.ts` builds the CLI with commander's `Command`/`Argument`/`InvalidArgumentError`, and no `yargs` reference remains in the sources, `package.json`, or `bun.lock`. No production code was changed here.
- Adds five e2e tests to `tests/e2e.test.ts` covering the argument-parsing layer that the migration replaced:
  - unsupported operator (`^`) rejected by the `.choices()` constraint
  - non-numeric operand rejected by the custom `parseNumber` parser
  - missing required argument
  - unknown command
  - `--help` output listing both commands and the `calc` signature
- Each test spawns the real CLI as a subprocess and asserts exit code, stdout, and stderr, rather than inspecting parser internals.

## Why

- The existing e2e tests only exercised happy paths (`hello`, `calc` with `+` and `%`), so commander's validation and error-reporting behavior — the exact surface the yargs-to-commander swap changed — had no coverage.
- Driving the built CLI end to end was chosen over unit-testing the command object so the assertions reflect what a user actually sees, and remain valid if the CLI framework is swapped again.

## Testing

- `bun test` — 13 pass, 0 fail (was 8 before this change).
- Expected stderr messages and exit codes were confirmed against the real CLI (`bun run src/index.ts calc 2 '^' 3`, `calc x + 3`, `calc 2 +`, `bogus`, `--help`) before being written as assertions.

## Notes

- No breaking changes.
- Tests live in `tests/` to match the existing repository layout. The team testing guideline prescribes `test/unit` and `test/e2e`; aligning the directory structure is left as follow-up work since it affects the existing suite as well.
- Stale `node_modules/yargs*` directories remain on disk because the hoisted linker does not prune them. They are gitignored and unreferenced; a clean install removes them.
