### PR TITLE
docs: document calculator commands and modulo usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ To install dependencies:
 bun install
 ```
 
-To run:
+To print the greeting:
 
 ```bash
-bun run src/index.ts
+bun run src/index.ts hello
+```
+
+To calculate with `+`, `-`, `*`, `/`, or `%`:
+
+```bash
+bun run src/index.ts calc 13 % 5
+# 3
 ```
 
 This project was created using `bun init` in bun v1.3.5. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.


### PR DESCRIPTION
Close #4

## Customer Summary

- Document how to run the greeting command and the calculator from the command line.
- List all supported calculator operators, including modulo (`%`), with a concrete example and result.
- No rollout, compatibility, or migration steps are required.

## Technical Summary

- Replace the incomplete bare entry-point example in `README.md` with the explicit `hello` subcommand.
- Add the `calc <left> <operator> <right>` invocation pattern and a modulo example using `13 % 5`.
- This PR changes documentation only; calculator runtime behavior is unchanged.

## Why

- The previous README command omitted the required subcommand and did not explain the calculator interface.
- A short executable example makes modulo support discoverable while keeping the documentation concise.

## Testing

- `bun test` (8 tests passed)
- `bunx tsc --noEmit`
- `git diff --check`
