### PR TITLE
test: cover commander-based CLI parsing, validation, and help output

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,4 +44,48 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
   });
+
+  test("calc accepts decimal and negative operands", async () => {
+    const result = await runCli(["calc", "--", "-4.5", "/", "2"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("-2.25");
+  });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "2", "^", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'^' is invalid for argument 'operator'");
+    expect(result.stderr).toContain("+, -, *, /, %");
+  });
+
+  test("calc rejects a non-numeric operand", async () => {
+    const result = await runCli(["calc", "a", "+", "1"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'a' is not a number.");
+  });
+
+  test("calc rejects a missing operand", async () => {
+    const result = await runCli(["calc", "2", "+"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("missing required argument 'right'");
+  });
+
+  test("--help lists every available command", async () => {
+    const result = await runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Usage: agent-benchmark");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc <left> <operator> <right>");
+  });
+
+  test("an unknown command fails with an error", async () => {
+    const result = await runCli(["bogus"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("unknown command 'bogus'");
+  });
 });


### PR DESCRIPTION
Close #167

## Customer Summary

- No user-visible behavior changes: the CLI keeps the same `hello` and `calc` commands with identical output.
- Adds automated checks that the CLI reports clear, helpful errors for bad input (unknown command, unsupported operator, non-numeric or missing operand) and that `--help` lists every command.
- Protects the recently completed switch to the commander argument parser from silent regressions, so users keep getting understandable error messages instead of crashes.

## Technical Summary

- Extends `tests/e2e.test.ts` with six subprocess-level CLI tests that spawn `src/index.ts` and assert stdout, stderr, and exit codes.
- Covers commander-specific surfaces that were previously untested: `Argument().choices()` validation for the operator, `InvalidArgumentError` from the numeric parser, missing-required-argument handling, top-level `--help` output, and unknown-command failure.
- Also covers decimal and negative operands (`calc -- -4.5 / 2`).
- No production code changes: `src/index.ts` already uses commander and `yargs` is absent from `package.json`, `bun.lock`, and the source tree.

## Why

- The commander migration (issue #167) landed with only happy-path coverage, so the parser's validation and help behavior — the main reason to use an argument-parsing library — was unverified.
- Testing through the real CLI process rather than by asserting parser configuration keeps the tests tied to externally visible behavior and avoids duplicating implementation details.

## Testing

- `bunx tsc --noEmit`
- `bun test` — 14 pass, 0 fail, 36 expect() calls
- Each asserted error string was first confirmed by running the real CLI manually (e.g. `bun run src/index.ts calc 2 '^' 3`) rather than guessed.

## Notes

- No breaking changes. Stale `node_modules/yargs*` directories left over from before the migration were removed locally; they were not tracked by git and are not in `bun.lock`.
