### PR TITLE
test: cover commander-based CLI parsing, help, and error handling

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,4 +44,51 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
   });
+
+  test("calc accepts negative and fractional operands", async () => {
+    const negative = await runCli(["calc", "-5", "%", "3"]);
+    expect(negative.exitCode).toBe(0);
+    expect(negative.stdout).toBe("-2");
+
+    const fractional = await runCli(["calc", "2.5", "*", "4"]);
+    expect(fractional.exitCode).toBe(0);
+    expect(fractional.stdout).toBe("10");
+  });
+
+  test("--help lists every available command", async () => {
+    const result = await runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Usage: agent-benchmark");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc <left> <operator> <right>");
+  });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "1", "^", "2"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'^' is invalid for argument 'operator'");
+    expect(result.stderr).toContain("+, -, *, /, %");
+  });
+
+  test("calc rejects a non-numeric operand", async () => {
+    const result = await runCli(["calc", "abc", "+", "2"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'abc' is not a number.");
+  });
+
+  test("calc reports a missing operand", async () => {
+    const result = await runCli(["calc", "1", "+"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("missing required argument 'right'");
+  });
+
+  test("an unknown command fails with an error", async () => {
+    const result = await runCli(["bogus"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("unknown command 'bogus'");
+  });
 });


### PR DESCRIPTION
Close #167

## Customer Summary

- No user-visible behavior changes. The command-line tool works exactly as before.
- The `agent-benchmark` CLI is now confirmed to be fully powered by `commander`, with `yargs` no longer used anywhere in the project.
- Adds automated checks that the tool prints the right help text and clear, friendly error messages when someone types an invalid command or an invalid number.
- No migration or rollout steps are required.

## Technical Summary

- Adds six e2e tests to `tests/e2e.test.ts` that spawn the real CLI via `Bun.spawn` and assert `stdout`, `stderr`, and exit code.
- New coverage: negative and fractional operands (`-5 % 3`, `2.5 * 4`), `--help` usage/command listing, invalid operator choice, non-numeric operand (`InvalidArgumentError`), missing required argument, and unknown command.
- No production code changes: the `yargs` -> `commander` migration itself already landed in `dd2c9b1`, and `commander@15.0.0` is the only CLI dependency in `package.json` and `bun.lock`.
- Tests live in `tests/` to match the existing repository layout (`tests/unit.test.ts`, `tests/e2e.test.ts`), which is what `bun test` discovers here.

## Why

- The issue asked to install and use `commander` and remove `yargs`. Inspection showed the migration was already complete: `src/index.ts` builds the CLI with `Command`/`Argument`/`InvalidArgumentError`, and `yargs` appears nowhere in the source, `package.json`, `bun.lock`, or `node_modules`.
- What was missing was verification. The existing e2e suite only exercised happy paths (`hello`, `calc 2 + 3`, `calc 13 % 5`), so none of the commander-specific parsing, validation, help, or error behavior was pinned down.
- Testing through the spawned CLI process asserts externally visible behavior rather than commander's internal wiring, so the suite would still pass if the argument-parsing library were swapped again.

## Testing

- `bun test` -> 14 pass, 0 fail, 37 expect() calls across 2 files.
- `bunx tsc --noEmit` -> clean.
- Manually ran the CLI to confirm each asserted behavior: `bun run src/index.ts --help`, `calc 1 ^ 2`, `calc abc + 2`, `calc 1 +`, `bogus`, `calc -5 % 3`, `calc 2.5 '*' 4`.

## Notes

- No breaking changes.
- Follow-up (optional): the shared testing guidelines specify `test/unit` and `test/e2e` directories, while this repo uses `tests/`. Restructuring was left out of scope to avoid an unrelated churn in this PR.
