### PR TITLE
fix: print Hello, World from documented command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,10 @@ const program = new Command();
 
 program.name("agent-benchmark");
 
+program.action(() => {
+  console.log(currentText);
+});
+
 program
   .command("hello")
   .description("Print the current text")

--- a/test/unit/hello.test.ts
+++ b/test/unit/hello.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+test("the documented CLI invocation prints Hello, World!", async () => {
+  const process = Bun.spawn(["bun", "run", "src/index.ts"], {
+    cwd: projectRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  expect(stdout).toBe("Hello, World!\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Close #1

## Customer Summary

- Running the README-documented command now prints `Hello, World!`.
- Existing `hello` and `calc` subcommands continue to work without migration or rollout steps.

## Technical Summary

- Add a root Commander action that prints the shared `currentText` value when the CLI runs without a subcommand.
- Add a subprocess regression test covering stdout, stderr, and the exit code for `bun run src/index.ts`.

## Why

- The documented no-argument command exited successfully without printing the expected greeting.
- Reusing `currentText` keeps the root command and `hello` subcommand output consistent without duplicating the string.

## Testing

- `bun test test/unit/hello.test.ts`
- `bun test`
- `bun run src/index.ts hello`
- `bun run src/index.ts calc 7 % 4`
