### PR TITLE
refactor: centralize arithmetic operator definitions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {


### PR DESCRIPTION
Close #4

## Customer Summary

- Keeps modulo and the other arithmetic operators consistently available through the calculator CLI.
- No command syntax, output, compatibility, or migration changes are required.

## Technical Summary

- Defines the supported operator tuple once in `src/cli.ts` and derives the `Operator` type from it.
- Reuses the same tuple for Commander argument validation, preventing CLI choices and calculator types from drifting apart.
- Moves calculator and subprocess CLI coverage under `test/unit`, where the repository testing workflow discovers it.

## Why

- The CLI choices and TypeScript operator union were maintained separately, creating a risk that future changes would update only one layer.
- A single tuple provides a small, type-safe source of truth while preserving existing behavior.

## Testing

- `bun test test/unit/` (8 passed, 0 failed)
- `bunx tsc --noEmit`
