### PR TITLE
test: cover commander CLI argument validation and help output

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,4 +44,49 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
   });
+
+  test("calc accepts negative operands", async () => {
+    const result = await runCli(["calc", "-3", "*", "-4"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("12");
+  });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "2", "^", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'^' is invalid for argument 'operator'");
+    expect(result.stderr).toContain("+, -, *, /, %");
+  });
+
+  test("calc rejects a non-numeric operand", async () => {
+    const result = await runCli(["calc", "a", "+", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'a' is not a number.");
+  });
+
+  test("calc reports a missing operand", async () => {
+    const result = await runCli(["calc", "2", "+"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("missing required argument 'right'");
+  });
+
+  test("an unknown command fails with an error", async () => {
+    const result = await runCli(["bogus"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("unknown command 'bogus'");
+  });
+
+  test("--help lists the available commands", async () => {
+    const result = await runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Usage: agent-benchmark");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc <left> <operator> <right>");
+  });
 });


### PR DESCRIPTION
Close #167

## Customer Summary

- No user-visible change. The `agent-benchmark` CLI behaves exactly as before; this PR only adds automated tests.
- The tests lock in how the CLI responds to bad input, so future changes cannot silently break the error messages people see when they mistype a command.
- Covered situations: an unsupported operator, a non-numeric operand, a missing operand, an unknown command, and the `--help` listing.
- No rollout, compatibility, or migration steps required.

## Technical Summary

- Adds 6 tests to `tests/e2e.test.ts`, spawning `src/index.ts` as a real subprocess and asserting stdout, stderr, and exit code. No mocks or stubs.
- New coverage: negative operands (`calc -3 * -4` -> `12`, confirming commander does not misparse `-3` as an option flag), `Argument.choices` rejection of `^`, the custom `parseNumber` / `InvalidArgumentError` path, commander's missing-required-argument error, unknown-command handling, and the `--help` usage banner.
- No production code changed. `src/index.ts`, `src/cli.ts`, and `package.json` are untouched.

## Why

- Issue #167 asked to install and use commander and remove yargs. That migration had already landed on `main` in dd2c9b1 ("feat: employ commander, support modulo operator, and correct hello output", #569): commander@15.0.0 is a dependency, `src/index.ts` is built on `Command`/`Argument`/`InvalidArgumentError`, and yargs is absent from `package.json`, `bun.lock`, and all source. There was no migration work left to do.
- The real gap was test coverage: the existing suite only exercised happy paths (`hello`, `calc 2 + 3`, `calc 13 % 5`), so none of commander's argument parsing, validation, or error reporting was verified. Rather than produce a no-op commit, this PR closes that gap.
- Tests drive the built CLI end-to-end rather than asserting on parser configuration, per the project testing guidelines (prefer the broadest practical test type; avoid asserting assembled parameters).

## Testing

- `bun test` -> 14 pass, 0 fail, 37 expect() calls across 2 files.
- Manually confirmed each error path before writing assertions, e.g. `bun run src/index.ts calc 2 '^' 3` (exit 1, "Allowed choices are +, -, *, /, %."), `calc a + 3` (exit 1, "'a' is not a number."), `calc 2 +` (exit 1, "missing required argument 'right'"), and `calc -3 + 4` (exit 0).

## Notes

- The `Close #167` line is retained from the existing PR body, but note that issue #167 is already CLOSED and was resolved by #569. This PR does not itself perform the yargs-to-commander migration; it adds regression tests for the migrated CLI.
- Tests live in `tests/`, following the existing repo layout. The testing guidelines specify `test/unit` and `test/e2e` for `wb test` discovery, so if this project is meant to run under `wb test`, these files may not be picked up. Relocating them was left out of scope as a follow-up.
- The remaining `yargs` references under `.claude/worktrees/` are stale worktree copies, not part of the project tree.
