### PR TITLE
feat: keep modulo operator support consistent

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "index.ts");
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {


### PR DESCRIPTION
Close #4

## Customer Summary

- Keeps modulo calculations available through the `calc` command with the `%` operator.
- Ensures the command-line interface and calculator recognize the same supported operators.
- Requires no migration or configuration changes.

## Technical Summary

- Defines the supported arithmetic operators once in `src/cli.ts` and derives the `Operator` type from that immutable list.
- Reuses the shared operator list for Commander CLI choice validation, preventing runtime validation and TypeScript types from drifting apart.
- Moves calculator and CLI subprocess tests under `test/unit` so the configured test workflow discovers them.

## Why

- Modulo support must remain consistent across calculation logic, compile-time types, and command-line validation.
- A single source of truth keeps the implementation small and prevents future operator additions from requiring duplicated updates.

## Testing

- `bun test` (8 tests passed)
- `bunx tsc --noEmit`
