### PR TITLE
feat: keep modulo support consistent across the CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {


### PR DESCRIPTION
Close #4

## Customer Summary

- Keep the modulo (`%`) operator available through the calculator CLI alongside addition, subtraction, multiplication, and division.
- Ensure the command-line interface and calculation engine recognize the same set of operators.
- No migration or compatibility action is required.

## Technical Summary

- Define the supported operator tuple once in `src/cli.ts` and derive the `Operator` type from it.
- Reuse that tuple for Commander argument validation so runtime choices cannot drift from the calculation API.
- Place calculation and real CLI-process coverage under `test/unit`, including positive, negative, decimal, and end-to-end modulo behavior.

## Why

- Maintaining separate runtime and compile-time operator lists could allow modulo support to become inconsistent between the CLI and calculation engine.
- A single source of truth keeps the implementation small and prevents that class of regression.

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `git diff --check`
