### PR TITLE
fix: print Hello World by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,9 @@ function parseNumber(value: string): number {
 
 const program = new Command();
 
-program.name("agent-benchmark");
+program.name("agent-benchmark").action(() => {
+  console.log(currentText);
+});
 
 program
   .command("hello")

--- a/test/e2e/hello.test.ts
+++ b/test/e2e/hello.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
+
+test("the documented command prints Hello, World!", async () => {
+  const proc = Bun.spawn(["bun", "run", entry], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(stdout).toBe("Hello, World!\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});

--- a/test/e2e/hello.test.ts
+++ b/test/e2e/hello.test.ts
@@ -6,7 +6,6 @@ const entry = join(
   dirname(fileURLToPath(import.meta.url)),
   "..",
   "..",
-  "..",
   "src",
   "index.ts",
 );


### PR DESCRIPTION
Close #1

## Customer Summary

- Running the documented `bun run src/index.ts` command now prints `Hello, World!` and exits successfully.
- Existing `hello` and calculator subcommands continue to work without migration or compatibility changes.

## Technical Summary

- Added a root Commander action that prints the existing `currentText` value when no subcommand is supplied.
- Added an end-to-end test that runs the repository entry point and verifies exact stdout, empty stderr, and a successful exit code.

## Why

- The documented no-argument command previously completed without output because only subcommands had actions.
- A root action is the smallest change that restores the expected default output while preserving existing subcommand routing.

## Testing

- `bun test test/e2e/hello.test.ts`
- `bun test`
- `bunx tsc --noEmit`
