### PR TITLE
feat: employ commander for the CLI instead of yargs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Argument, Command, InvalidArgumentError } from "commander";
+import { Argument, Command, CommanderError, InvalidArgumentError } from "commander";
 import { calculate, currentText, type Operator } from "./cli";
 
 const operators: Operator[] = ["+", "-", "*", "/", "%"];
@@ -14,6 +14,11 @@ function parseNumber(value: string): number {
 const program = new Command();
 
 program.name("agent-benchmark");
+
+// Commander exits via `process.exit()` right after writing help or an error message, which can
+// discard output that is still buffered when stdout/stderr are pipes. Set the exit code instead so
+// the process ends only once its output has been flushed.
+program.exitOverride();
 
 program
   .command("hello")
@@ -32,4 +37,9 @@ program
     console.log(calculate(left, operator, right));
   });
 
-program.parse();
+try {
+  program.parse();
+} catch (error) {
+  if (!(error instanceof CommanderError)) throw error;
+  process.exitCode = error.exitCode;
+}

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,4 +44,41 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
   });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "2", "^", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'operator'");
+    expect(result.stderr).toContain("+, -, *, /, %");
+  });
+
+  test("calc rejects a non-numeric operand", async () => {
+    const result = await runCli(["calc", "x", "+", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'x' is not a number.");
+  });
+
+  test("calc rejects a missing operand", async () => {
+    const result = await runCli(["calc", "2", "+"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("missing required argument 'right'");
+  });
+
+  test("help lists the available commands", async () => {
+    const result = await runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Usage: agent-benchmark");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc <left> <operator> <right>");
+  });
+
+  test("an unknown command fails", async () => {
+    const result = await runCli(["bogus"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("unknown command 'bogus'");
+  });
 });


### PR DESCRIPTION
Close #167

## Customer Summary

- The command-line tool now uses a different underlying argument-parsing library, keeping the same commands (`hello`, `calc <left> <operator> <right>`) and the same output.
- Invalid input still fails with a clear message, e.g. an unsupported operator, a non-numeric operand, a missing operand, or an unknown command; `--help` lists the available commands.
- Error and help messages are now reliably shown in full. Previously they could occasionally come out empty when the CLI's output was captured by another program (scripts, CI, tests).
- No migration or configuration changes are needed.

## Technical Summary

- `src/index.ts` builds the CLI with `commander`: a `hello` command, and a `calc` command with `parseNumber` argument parsers for the operands and an `Argument(...).choices(...)` constraint for the operator; `yargs` is gone.
- The program uses `program.exitOverride()` and sets `process.exitCode` from the thrown `CommanderError` instead of letting commander call `process.exit()`. Unexpected non-`CommanderError` exceptions are rethrown.
- `tests/e2e.test.ts` adds CLI-level coverage for the unsupported operator, non-numeric operand, missing operand, `--help` output, and unknown command paths, alongside the existing success cases.

## Why

- The issue asked to adopt commander and drop yargs.
- Commander's default failure path writes the message to stderr and then immediately calls `process.exit()`. When stdout/stderr are pipes, the buffered write races that exit: the output can be discarded and the process can stall during teardown. This surfaced as a flaky `bun test` failure where a spawned CLI produced empty stderr and hung past the 5s test timeout, leaving a dangling process.
- Setting `process.exitCode` and returning normally lets the process exit only after its output has flushed, which fixes both the truncated output and the stall, and it also covers the `--help` path on stdout. It preserves commander's exit codes (1 for errors, 0 for help).

## Testing

- `bun test` — 13 pass, 0 fail; run repeatedly warm and under 16-way CPU load to check for the flake.
- `bunx tsc --noEmit` — clean.
- Manual: `bun src/index.ts calc 13 % 5` → `3`; `calc x + 3`, `calc 2 +`, `calc 2 ^ 3`, and `bogus` each print their error to stderr and exit 1; `--help` prints usage and exits 0.
