### PR TITLE
fix: print Hello, World! for default invocation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,9 @@ function parseNumber(value: string): number {
 
 const program = new Command();
 
-program.name("agent-benchmark");
+program.name("agent-benchmark").action(() => {
+  console.log(currentText);
+});
 
 program
   .command("hello")

--- a/test/e2e/hello.test.ts
+++ b/test/e2e/hello.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
+
+test("the documented CLI invocation prints Hello, World!", async () => {
+  const process = Bun.spawn(["bun", "run", entry], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  expect({ exitCode, stderr, stdout }).toEqual({
+    exitCode: 0,
+    stderr: "",
+    stdout: "Hello, World!\n",
+  });
+});


### PR DESCRIPTION
Close #1

## Customer Summary

- Running the documented `bun run src/index.ts` command now prints `Hello, World!` and exits successfully.
- Existing `hello` and calculator subcommands continue to work as before.
- No migration or configuration changes are required.

## Technical Summary

- Add a root Commander action that prints the existing `currentText` greeting when no subcommand is provided.
- Add an end-to-end regression test that checks the exact exit code, stdout, and stderr of the documented invocation.

## Why

- The CLI previously treated an invocation without arguments as an error and printed usage information, despite the README documenting that invocation as the normal way to run the program.
- A root action is the smallest change that restores the documented behavior without changing existing subcommands.

## Testing

- `bun test test/e2e/hello.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- Manually ran `bun run src/index.ts` and verified exit code 0, stdout exactly `Hello, World!\n`, and empty stderr.
