### PR TITLE
feat: greet on bare invocation and cover the commander CLI with tests

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
-export const currentText = "Hello, World!";
+export const currentText = "Hello via Bun!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export const operators = ["+", "-", "*", "/", "%"] as const;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const program = new Command();
 program.name("agent-benchmark");
 
 program
-  .command("hello")
+  .command("hello", { isDefault: true })
   .description("Print the current text")
   .action(() => {
     console.log(currentText);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,4 +30,8 @@ program
     console.log(calculate(left, operator, right));
   });
 
-program.parse();
+// The README documents `bun run src/index.ts` as the way to run the project, so a
+// bare invocation greets. `hello` is not registered as commander's default command
+// because that would swallow unknown commands as its arguments.
+const args = process.argv.slice(2);
+program.parse(args.length > 0 ? args : ["hello"], { from: "user" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);
@@ -16,7 +14,7 @@ const program = new Command();
 program.name("agent-benchmark");
 
 program
-  .command("hello", { isDefault: true })
+  .command("hello")
   .description("Print the current text")
   .action(() => {
     console.log(currentText);

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -30,24 +30,59 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("the documented command prints Hello, World!", async () => {
-    const result = await runCli([]);
+  test("hello prints Hello, World!", async () => {
+    const result = await runCli(["hello"]);
     expect(result.stdout).toBe("Hello, World!");
     expect(result.stderr).toBe("");
     expect(result.exitCode).toBe(0);
   });
 
-  test("calc prints only the number result", async () => {
-    const result = await runCli(["calc", "2", "+", "3"]);
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("5");
+  test.each([
+    ["2", "+", "3", "5"],
+    ["10", "-", "4", "6"],
+    ["3", "*", "4", "12"],
+    ["12", "/", "3", "4"],
+    ["13", "%", "5", "3"],
+    ["-13", "%", "5", "-3"],
+    ["7.5", "%", "2", "1.5"],
+  ])(
+    "calc prints only the result of %s %s %s",
+    async (left, operator, right, expected) => {
+      const result = await runCli(["calc", left, operator, right]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe(expected);
+    },
+  );
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "7", "^", "2"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Allowed choices are +, -, *, /, %.");
   });
 
-  test("calc computes the modulo of two numbers", async () => {
-    const result = await runCli(["calc", "13", "%", "5"]);
+  test("calc rejects a non-numeric operand", async () => {
+    const result = await runCli(["calc", "abc", "+", "1"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'abc' is not a number.");
+  });
+
+  test("an unknown command fails with an error", async () => {
+    const result = await runCli(["frobnicate"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toStartWith("error:");
+    expect(result.stderr).toContain("frobnicate");
+  });
+
+  test("--help documents both subcommands", async () => {
+    const result = await runCli(["--help"]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("3");
+    expect(result.stdout).toContain("Usage: agent-benchmark");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc <left> <operator> <right>");
   });
 });

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -30,6 +30,14 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
+  // The README documents `bun run src/index.ts` as the way to run the project.
+  test("the documented command prints Hello, World!", async () => {
+    const result = await runCli([]);
+    expect(result.stdout).toBe("Hello, World!");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
   test("hello prints Hello, World!", async () => {
     const result = await runCli(["hello"]);
     expect(result.stdout).toBe("Hello, World!");
@@ -73,8 +81,7 @@ describe("cli", () => {
     const result = await runCli(["frobnicate"]);
     expect(result.exitCode).toBe(1);
     expect(result.stdout).toBe("");
-    expect(result.stderr).toStartWith("error:");
-    expect(result.stderr).toContain("frobnicate");
+    expect(result.stderr).toContain("unknown command 'frobnicate'");
   });
 
   test("--help documents both subcommands", async () => {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {
@@ -24,11 +30,11 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
-    const result = await runCli(["hello"]);
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
+  test("the documented command prints Hello, World!", async () => {
+    const result = await runCli([]);
     expect(result.stdout).toBe("Hello, World!");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
   });
 
   test("calc prints only the number result", async () => {


### PR DESCRIPTION
Close #167

## Customer Summary

- Running the documented command `bun run src/index.ts` with no arguments now prints `Hello, World!` instead of showing the usage text and failing.
- The subcommands are unchanged: `hello` prints the greeting, and `calc <left> <operator> <right>` prints the result of `+`, `-`, `*`, `/`, or `%`.
- Mistakes are still reported clearly: an unsupported operator, a non-numeric operand, or an unknown command prints an error and exits with a non-zero status.
- No migration or configuration work is needed for users.

## Technical Summary

- The CLI is built with `commander` (`Command`, `Argument(...).choices()`, `InvalidArgumentError`); `yargs` is no longer referenced anywhere in `package.json`, `bun.lock`, `src/`, or `test/`.
- `src/index.ts` falls back to `program.parse(["hello"], { from: "user" })` when no arguments are given, rather than registering `hello` with `isDefault: true`, which would swallow unknown commands as arguments of `hello`.
- `src/cli.ts` exports a single `operators` tuple and derives the `Operator` type from it, so the runtime choices passed to commander and the compile-time type cannot drift apart.
- Tests moved from `tests/` to `test/unit/`, and `test/unit/cli.test.ts` drives the real CLI through `Bun.spawn` instead of asserting on parser wiring: every operator, invalid operator, non-numeric operand, unknown command, and `--help` output.

## Why

- Issue #167 asked to adopt `commander` and drop `yargs`, but the adoption had no tests covering what commander is responsible for: argument validation, error messages, help output, and unknown-command handling.
- Spawning the actual CLI is the broadest practical test type here, so the tests verify externally visible behavior (stdout, stderr, exit code) rather than duplicating the implementation.

## Testing

- `bun test` — all tests pass.
- Manual checks: `bun run src/index.ts` prints `Hello, World!`; `bun run src/index.ts calc 13 % 5` prints `3`; `bun run src/index.ts calc 7 ^ 2` fails with `Allowed choices are +, -, *, /, %.`; `bun run src/index.ts frobnicate` fails with `unknown command 'frobnicate'`.

## Notes

- No breaking changes; the only behavioral difference is that a bare invocation greets instead of exiting with the usage error.
