### PR TITLE
refactor: keep calculator operators in sync

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello, World!";
+export const currentText = "Hello via Bun!";
 
 export const operators = ["+", "-", "*", "/", "%"] as const;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-export const currentText = "Hello via Bun!";
+export const currentText = "Hello, World!";
 
 export const operators = ["+", "-", "*", "/", "%"] as const;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "index.ts");
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -24,11 +24,13 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
+  test('hello prints "Hello, World!" instead of "Hello via Bun!"', async () => {
     const result = await runCli(["hello"]);
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("Hello, World!");
+    expect(result).toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: "Hello, World!",
+    });
   });
 
   test("calc prints only the number result", async () => {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -24,7 +24,16 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test('hello prints "Hello, World!" instead of "Hello via Bun!"', async () => {
+  test("help lists the available commands", async () => {
+    const result = await runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Usage: agent-benchmark [options] [command]");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc <left> <operator> <right>");
+  });
+
+  test('hello prints "Hello, World!"', async () => {
     const result = await runCli(["hello"]);
     expect(result).toEqual({
       exitCode: 0,
@@ -51,5 +60,35 @@ describe("cli", () => {
       stderr: "",
       stdout: expected,
     });
+  });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "2", "^", "3"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("value '^' is invalid");
+    expect(result.stderr).toContain("Allowed choices are +, -, *, /, %");
+  });
+
+  test("calc rejects a non-numeric operand", async () => {
+    const result = await runCli(["calc", "two", "+", "3"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("value 'two' is invalid");
+    expect(result.stderr).toContain("'two' is not a number");
+  });
+
+  test("calc rejects a missing operand", async () => {
+    const result = await runCli(["calc", "2", "+"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("missing required argument 'right'");
+  });
+
+  test("an unknown command fails", async () => {
+    const result = await runCli(["bye"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("unknown command 'bye'");
   });
 });

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -38,10 +38,16 @@ describe("cli", () => {
     expect(result.stdout).toBe("5");
   });
 
-  test("calc computes the modulo of two numbers", async () => {
-    const result = await runCli(["calc", "13", "%", "5"]);
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("3");
+  test.each([
+    ["13", "5", "3"],
+    ["-13", "5", "-3"],
+    ["7.5", "2", "1.5"],
+  ])("calc computes %s %% %s as %s", async (left, right, expected) => {
+    const result = await runCli(["calc", left, "%", right]);
+    expect(result).toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: expected,
+    });
   });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,10 +17,4 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
-
-  test("computes the remainder", () => {
-    expect(calculate(13, "%", 5)).toBe(3);
-    expect(calculate(-13, "%", 5)).toBe(-3);
-    expect(calculate(7.5, "%", 2)).toBe(1.5);
-  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- Keeps modulo calculations available through the `calc` command and verifies results for positive, negative, and decimal operands.
- Prevents supported calculator operators from becoming inconsistent between command-line validation and calculation behavior.
- Improves confidence that help text and invalid-command errors remain clear, with no migration or usage changes required.

## Technical Summary

- Exports a single readonly operator list from `src/cli.ts` and derives the `Operator` type from it.
- Reuses that list for Commander's operator choices in `src/index.ts`, eliminating duplicate operator definitions.
- Moves automatically discovered tests under `test/unit` and exercises modulo behavior through real CLI subprocesses.
- Covers Commander help output, invalid numbers and operators, missing arguments, unknown commands, and the `hello` output regression.

## Why

- The calculator's runtime choices and TypeScript operator type should have one source of truth so they cannot drift as operators are added.
- CLI-level tests verify parsing, validation, output, and errors as users experience them while avoiding duplicate unit coverage.

## Testing

- `bun test` (14 tests passed)
- `bunx tsc --noEmit`
- `git diff --check origin/main...HEAD`
