### PR TITLE
test: cover commander CLI validation and help output

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,4 +44,48 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
   });
+
+  test("calc accepts negative and fractional operands", async () => {
+    const result = await runCli(["calc", "-7.5", "*", "2"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("-15");
+  });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "2", "^", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'^'");
+  });
+
+  test("calc rejects a non-numeric operand", async () => {
+    const result = await runCli(["calc", "two", "+", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'two' is not a number.");
+  });
+
+  test("calc reports missing arguments", async () => {
+    const result = await runCli(["calc", "2"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("missing required argument");
+  });
+
+  test("--help lists the available commands", async () => {
+    const result = await runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("agent-benchmark");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc");
+  });
+
+  test("an unknown command fails", async () => {
+    const result = await runCli(["goodbye"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("unknown command");
+  });
 });


### PR DESCRIPTION
Close #167

## Customer Summary

- No user-visible change. The CLI behaves exactly as before: `hello` prints the greeting and `calc` evaluates two operands with `+`, `-`, `*`, `/`, or `%`.
- The commander migration requested in #167 was already merged to `main` in dd2c9b1; this branch adds the automated tests that prove the migrated CLI behaves correctly.
- Adds confidence that bad input is rejected with a clear message instead of silently producing a wrong answer, and that `--help` documents every command.

## Technical Summary

- Extends `tests/e2e.test.ts` with six CLI tests that spawn the real entry point (`bun run src/index.ts`) and assert stdout, stderr, and exit code.
- New coverage: negative/fractional operands, unsupported operator rejected by commander's `.choices()`, non-numeric operand rejected by the custom `parseNumber` (`InvalidArgumentError`), missing-argument reporting, `--help` listing both subcommands, and non-zero exit on an unknown command.
- No production code, dependency, or configuration changes. `commander` 15.0.0 is already the only CLI dependency; `grep -ri yargs` over sources, `package.json`, and `bun.lock` returns nothing.

## Why

- #167 asked to employ commander and remove yargs. Verification showed that work already landed on `main`, so reimplementing it would have produced an empty diff.
- The genuine gap was test coverage: the existing suite only exercised happy-path `hello` and `calc`, so none of the commander-specific behavior (choice validation, custom argument parsers, generated help, unknown-command handling) was pinned down. Testing at the process boundary follows the project guideline to prefer the broadest practical test type over asserting on assembled parameters.

## Testing

- `bun test` — 14 pass, 0 fail, 36 expect() calls across 2 files.
- `bun run tsc --noEmit` — no type errors.
- `wb verify --full` — install, cleanup, typecheck, and test all green.

## Notes

- The repository keeps tests in `tests/` rather than the `test/unit` and `test/e2e` layout described in the testing guidelines. CI runs a plain `bun test`, which discovers them, so the existing layout was preserved; migrating the directories would be a separate change.
