### PR TITLE
fix: print Hello, World! for documented command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,9 @@ function parseNumber(value: string): number {
 
 const program = new Command();
 
-program.name("agent-benchmark");
+program.name("agent-benchmark").action(() => {
+  console.log(currentText);
+});
 
 program
   .command("hello")

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -24,8 +24,8 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
-  test("hello prints the current text", async () => {
-    const result = await runCli(["hello"]);
+  test("the documented command prints Hello, World!", async () => {
+    const result = await runCli([]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("Hello, World!");


### PR DESCRIPTION
Close #1

## Customer Summary

- Running the documented `bun run src/index.ts` command with no arguments now prints `Hello, World!` and exits successfully.
- Existing `hello` and `calc` subcommands continue to work as before.
- No migration or configuration changes are required.

## Technical Summary

- Add a root Commander action that prints the existing `currentText` greeting when no subcommand is supplied.
- Update the CLI end-to-end regression test to invoke the documented no-argument command and assert its exact exit code, stderr, and stdout.
- Limit the production change to `src/index.ts`; subcommand dispatch remains unchanged.

## Why

- The documented command previously had no root action, so Commander exited with usage text instead of printing the greeting.
- A root action directly models the intended default CLI behavior while preserving the existing command structure.

## Testing

- `bun test tests/e2e.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `git diff --check`
