### PR TITLE
feat: strengthen modulo operator support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 export const currentText = "Hello, World!";
 
-export type Operator = "+" | "-" | "*" | "/" | "%";
+export const operators = ["+", "-", "*", "/", "%"] as const;
+
+export type Operator = (typeof operators)[number];
 
 export function calculate(left: number, operator: Operator, right: number): number {
   switch (operator) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
-import { calculate, currentText, type Operator } from "./cli";
-
-const operators: Operator[] = ["+", "-", "*", "/", "%"];
+import { calculate, currentText, operators, type Operator } from "./cli";
 
 function parseNumber(value: string): number {
   const parsed = Number(value);

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -38,10 +38,16 @@ describe("cli", () => {
     expect(result.stdout).toBe("5");
   });
 
-  test("calc computes the modulo of two numbers", async () => {
-    const result = await runCli(["calc", "13", "%", "5"]);
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("3");
-  });
+  for (const [left, right, expected] of [
+    ["13", "5", "3"],
+    ["-13", "5", "-3"],
+    ["7.5", "2", "1.5"],
+  ] as const) {
+    test(`calc computes ${left} modulo ${right}`, async () => {
+      const result = await runCli(["calc", left, "%", right]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe(expected);
+    });
+  }
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -17,10 +17,4 @@ describe("calculate", () => {
   test("divides", () => {
     expect(calculate(12, "/", 3)).toBe(4);
   });
-
-  test("computes the remainder", () => {
-    expect(calculate(13, "%", 5)).toBe(3);
-    expect(calculate(-13, "%", 5)).toBe(-3);
-    expect(calculate(7.5, "%", 2)).toBe(1.5);
-  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- Ensure the calculator's modulo operator remains available consistently through the command-line interface.
- Verify remainder calculations for positive integers, negative operands, and decimal operands.
- No migration or rollout steps are required.

## Technical Summary

- Define the supported arithmetic operators once and derive the TypeScript `Operator` type from that runtime list.
- Reuse the shared operator list for Commander argument validation so runtime choices and compile-time types cannot drift.
- Exercise modulo behavior through the real CLI path and remove duplicate lower-level assertions.

## Why

- The CLI's accepted operators and the calculator's operator type were maintained separately, which could allow modulo support to become inconsistent.
- A shared definition keeps the implementation simple while end-to-end tests verify user-visible behavior across representative numeric inputs.

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `git diff --check`
