### PR TITLE
test: cover rejection of unsupported operators in calc

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,4 +44,11 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
   });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "5", "^", "2"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("+, -, *, /, %");
+  });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- No user-visible change. The modulo operator (`%`) requested in #4 is already live on `main`: `calc 13 % 5` prints `3`, and `+`, `-`, `*`, `/`, `%` are all accepted.
- This PR only strengthens the automated test suite so that a future change cannot silently break which operators the CLI accepts.
- No rollout, compatibility, or migration impact.

## Technical Summary

- Adds one e2e test to `tests/e2e.test.ts` covering the rejection path of the `calc` operator choice list.
- The test runs the real CLI with an unsupported operator (`^`) and asserts a nonzero exit code, empty stdout, and an error message listing the allowed set `+, -, *, /, %`.
- No production code changed. `src/cli.ts` and `src/index.ts` are untouched.

## Why

- Issue #4 asked for modulo support. On inspection, `src/cli.ts` (`Operator` union and the `"%"` case) and `src/index.ts` (the `operators` choice list) already implement it, with unit coverage in `tests/unit.test.ts` and e2e coverage in `tests/e2e.test.ts`. Reimplementing it would have been a no-op.
- The one real gap was that nothing asserted the negative path of the operator list that `%` was added to, so a regression widening or breaking the accepted operator set would not fail any test. Driving the actual CLI process (rather than unit-testing the parser) keeps the assertion on observable behavior.

## Testing

- `bun test` — 9 pass, 0 fail (was 8 before this change).
- Manual CLI verification of the existing feature: `bun run src/index.ts calc 13 % 5` → `3`, `bun run src/index.ts calc -- -13 % 5` → `-3`, `bun run src/index.ts calc 7.5 % 2` → `1.5`, `bun run src/index.ts calc 5 '^' 2` → exit 1 with the allowed-choices error.

## Notes

- No breaking changes.
- If this branch was meant to start from a pre-modulo base commit, the base is wrong — the feature landed earlier in `dd2c9b1` / `4a4a590`.
