### PR TITLE
test: strengthen modulo CLI coverage

### DIFF
--- a/test/e2e/cli.test.ts
+++ b/test/e2e/cli.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 
-const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
+const entry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "index.ts",
+);
 
 async function runCli(args: string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {
@@ -38,10 +44,14 @@ describe("cli", () => {
     expect(result.stdout).toBe("5");
   });
 
-  test("calc computes the modulo of two numbers", async () => {
-    const result = await runCli(["calc", "13", "%", "5"]);
+  test.each([
+    ["13", "5", "3"],
+    ["-13", "5", "-3"],
+    ["7.5", "2", "1.5"],
+  ])("calc computes %s %% %s as %s", async (left, right, expected) => {
+    const result = await runCli(["calc", left, "%", right]);
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toBe("3");
+    expect(result.stdout).toBe(expected);
   });
 });

--- a/test/unit/calculate.test.ts
+++ b/test/unit/calculate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { calculate } from "../src/cli";
+import { calculate } from "../../src/cli";
 
 describe("calculate", () => {
   test("adds", () => {
@@ -20,7 +20,5 @@ describe("calculate", () => {
 
   test("computes the remainder", () => {
     expect(calculate(13, "%", 5)).toBe(3);
-    expect(calculate(-13, "%", 5)).toBe(-3);
-    expect(calculate(7.5, "%", 2)).toBe(1.5);
   });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- Verifies that modulo calculations work correctly for positive, negative, and decimal values through the command-line interface.
- Improves confidence in modulo support without changing existing runtime behavior or requiring migration.

## Technical Summary

- Moves the calculator unit tests to `test/unit` and CLI end-to-end tests to `test/e2e` to follow the repository testing layout.
- Expands the real CLI modulo test into table-driven coverage for integer, negative, and fractional operands.
- Keeps focused unit coverage for the calculator remainder operation.

## Why

- Modulo support needs regression coverage at the user-visible CLI boundary, including JavaScript remainder behavior for negative and fractional operands.
- The standardized test layout keeps automatic local and CI test discovery consistent.

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `git diff --check`
