### PR TITLE
feat: expose CLI version and verify commander behavior

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Argument, Command, InvalidArgumentError } from "commander";
+import packageJson from "../package.json" with { type: "json" };
 import { calculate, currentText, type Operator } from "./cli";
 
 const operators: Operator[] = ["+", "-", "*", "/", "%"];
@@ -13,7 +14,7 @@ function parseNumber(value: string): number {
 
 const program = new Command();
 
-program.name("agent-benchmark");
+program.name("agent-benchmark").version(packageJson.version);
 
 program
   .command("hello")

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import packageJson from "../package.json" with { type: "json" };
 
 const entry = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "index.ts");
 
-async function runCli(args: string[]) {
+async function runCli(args: readonly string[]) {
   const proc = Bun.spawn(["bun", "run", entry, ...args], {
     stdout: "pipe",
     stderr: "pipe",
@@ -24,6 +25,24 @@ async function runCli(args: string[]) {
 }
 
 describe("cli", () => {
+  test("help lists the available commands", async () => {
+    const result = await runCli(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Usage: agent-benchmark");
+    expect(result.stdout).toContain("hello");
+    expect(result.stdout).toContain("calc <left> <operator> <right>");
+  });
+
+  test("version matches the package version", async () => {
+    const result = await runCli(["--version"]);
+    expect(result).toEqual({
+      stdout: packageJson.version,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   test("hello prints the current text", async () => {
     const result = await runCli(["hello"]);
     expect(result.exitCode).toBe(0);
@@ -43,5 +62,35 @@ describe("cli", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
+  });
+
+  test("rejects an unknown command", async () => {
+    const result = await runCli(["unknown"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("unknown command 'unknown'");
+  });
+
+  test.each([
+    {
+      name: "a non-number operand",
+      args: ["calc", "nope", "+", "3"],
+      error: "'nope' is not a number",
+    },
+    {
+      name: "an unsupported operator",
+      args: ["calc", "2", "x", "3"],
+      error: "Allowed choices are +, -, *, /, %",
+    },
+    {
+      name: "a missing operand",
+      args: ["calc", "2", "+"],
+      error: "missing required argument 'right'",
+    },
+  ])("rejects $name", async ({ args, error }) => {
+    const result = await runCli(args);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(error);
   });
 });


### PR DESCRIPTION
Close #167

## Customer Summary

- Adds a `--version` option that reports the version published in the package metadata.
- Verifies that help, calculations, and clear failures for invalid commands or arguments continue to work after the Commander migration.
- No migration steps or breaking changes are required.

## Technical Summary

- Configures the Commander program version from `package.json` so runtime output stays synchronized with package releases.
- Expands process-level CLI tests for help and version output, unknown commands, non-numeric operands, unsupported operators, and missing operands.
- Keeps assertions focused on exit status and user-observable output rather than Commander internals.

## Why

- The Commander migration should retain the version capability previously provided by yargs.
- Broader CLI coverage protects command discovery and validation behavior from dependency or configuration regressions.

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `bun run src/index.ts --version`
- `git diff --check`
