### PR TITLE
test: cover modulo boundary cases and unsupported operator rejection

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,4 +44,18 @@ describe("cli", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe("3");
   });
+
+  test("calc keeps the sign of the left operand for modulo", async () => {
+    const result = await runCli(["calc", "-13", "%", "5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("-3");
+  });
+
+  test("calc rejects an unsupported operator", async () => {
+    const result = await runCli(["calc", "2", "^", "3"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'^'");
+  });
 });

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -22,5 +22,6 @@ describe("calculate", () => {
     expect(calculate(13, "%", 5)).toBe(3);
     expect(calculate(-13, "%", 5)).toBe(-3);
     expect(calculate(7.5, "%", 2)).toBe(1.5);
+    expect(calculate(13, "%", 0)).toBeNaN();
   });
 });


### PR DESCRIPTION
Close #4

## Customer Summary

- No user-visible behavior changes. The `calc` command's modulo support (`%`) already shipped on `main` and works as before.
- This change locks that behavior in with additional automated checks, so future edits cannot silently break modulo, negative operands, or the rejection of unsupported operators.
- No rollout, compatibility, or migration steps are needed.

## Technical Summary

- `tests/unit.test.ts`: assert `calculate(13, "%", 0)` is `NaN`, covering the divide-by-zero boundary for modulo (consistent with JS semantics, matching how `/` yields `Infinity`).
- `tests/e2e.test.ts`: add two CLI-level tests — `calc -13 % 5` prints `-3` (verifies the sign follows the left operand and that commander does not swallow the leading `-` as an option flag), and `calc 2 ^ 3` exits non-zero with empty stdout and `'^'` in stderr.
- No production code changed. `src/cli.ts` (`calculate`) and `src/index.ts` (operator choices) already handle `%`.

## Why

- The requested feature from #4 was already implemented on `main`, so rewriting it would have added churn without value.
- The gap that remained was test coverage: existing tests exercised only the happy path (`13 % 5`) and a couple of unit-level cases. Per the project testing guidelines, tests must cover error cases and boundary values, and should prefer the broadest practical test type.
- The new cases are driven through the real CLI process rather than the exported function, so they catch argument-parsing regressions that a unit test cannot.

## Testing

- `bun test` — 10 pass, 0 fail, 23 assertions across 2 files.

## Notes

- No breaking changes. Tests only; production behavior is unchanged.
